### PR TITLE
Add secondary color option for FQButton component

### DIFF
--- a/components/FQButton.tsx
+++ b/components/FQButton.tsx
@@ -3,7 +3,11 @@ import React, { FC } from 'react';
 import { TouchableOpacity } from 'react-native';
 import clsx from 'clsx';
 
-const FQButton: FC<TouchableOpacityProps> = (props) => {
+interface IFQButtonProps extends TouchableOpacityProps {
+  secondary?: boolean;
+}
+
+const FQButton: FC<IFQButtonProps> = (props) => {
   const renderChildren = () => {
     if (typeof props.children === 'string') {
       return (
@@ -20,8 +24,9 @@ const FQButton: FC<TouchableOpacityProps> = (props) => {
     <TouchableOpacity
       {...props}
       className={clsx('relative p-4 rounded h-[60px] ', {
-        'bg-blue': !props.disabled,
-        'bg-gray': props.disabled,
+        'bg-blue': !props.secondary,
+        'bg-gray': props.secondary,
+        'opacity-40': props.disabled,
       })}
     >
       {renderChildren()}

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -4,6 +4,9 @@ Brief description of your changes
 ### List of changes
 - Change 1
 
+### Did you install additional dependencies?
+- [ ] Yes
+
 ### Which part of the repository does your PR affect?
 - [ ] Sign In
 - [ ] Sign Up


### PR DESCRIPTION
### Description
Add secondary color option for FQButton component

### List of changes
- Added "secondary" prop option to FQButton to make button use have background color (as per design)
![image](https://github.com/user-attachments/assets/cf8b7fa9-89ce-4d5e-8bd8-a0688e8dab11)
![image](https://github.com/user-attachments/assets/9e6149d6-dbcf-425f-bbb2-e384a36abd58)

- Add question to check whether you have installed additional dependencies in pull request (PR) template

### Which part of the repository does your PR affect?
- [ ] Sign In
- [ ] Sign Up
- [ ] Onboarding
- [ ] Profile
- [ ] Workout
- [ ] Quest
- [ ] Shop
- [ ] Social
- [ ] Project Structure
- [x] Other. If so, specify: FQButton component, PR template