### PR TITLE
Feat: Implement refresh control in social screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,17 @@
 
    Users complete workouts by logging physical activities to gain progression on quests they embarked on.
 
-- **Avatar/Character Progression System**
+- **Character Progression System**
 
-   Users earn experience points which can be used to level up their character and earn gold to purchase new items in the shop.
+   Users earn experience points to level up their character which gives them attribute points to spend on customizing how their character grows.
 
 - **Dynamic Turn-Based Combat**
 
-   As users progress through quests, they will have the opportunity to fight against monsters and bosses to claim their hard-earned rewards.
+   As users progress through quests, they will have the opportunity to fight against monsters and bosses in a dynamic turn-based combat encounter.
+
+- **Virtual Rewards**
+
+   As users defeat monsters, they earn gold which can be used to purchase cooler and stronger items.
 
 - **Social Connection**
 

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -9,12 +9,15 @@ import { fetchItems, setItemsInDB } from '@/services/item';
 import { useItemStore } from '@/store/item';
 import { Alert } from 'react-native';
 import { MOCK_ITEMS } from '@/constants/item';
+import { useSocialStore } from '@/store/social';
+import { getUserFriends } from '@/services/social';
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();
 
   const { user } = useUserStore();
   const { setItems } = useItemStore();
+  const { setFriends, setPendingRequests, setSentRequests } = useSocialStore();
 
   if (!user) return <Redirect href={'/sign-in' as Href} />;
 
@@ -46,8 +49,25 @@ export default function TabLayout() {
       }
     };
 
+    const fetchUserFriends = async () => {
+      console.log('Fetching user friends');
+
+      if (!user?.id) {
+        return;
+      }
+
+      // Fetch user friends
+      const userFriendsResponse = await getUserFriends(user?.id);
+      if (userFriendsResponse.success && userFriendsResponse.data) {
+        setFriends(userFriendsResponse.data.friends);
+        setPendingRequests(userFriendsResponse.data.pendingRequests);
+        setSentRequests(userFriendsResponse.data.sentRequests);
+      }
+    };
+
     // _setItemsData();
     fetchItemsData();
+    fetchUserFriends();
   }, []);
 
   return (

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -49,9 +49,6 @@ const ItemCard = ({ item, onPress }: ItemCardProps) => {
       >
         <Sprite id={item.spriteID} width={70} height={70} />
       </TouchableOpacity>
-      <Text className="text-lg text-gold mb-5 font-semibold">
-        {item.cost} Gold
-      </Text>
     </View>
   );
 };
@@ -225,7 +222,7 @@ const Profile = () => {
         </View>
 
         {/* Items Grid */}
-        <View className="mt-8">
+        <View className="mt-2">
           <Text className="font-bold mb-2 text-xl text-grayDark">ITEMS</Text>
           {userItems.length > 0 ? (
             <View className="flex-row flex-wrap gap-y-4">

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -190,7 +190,7 @@ const Profile = () => {
             </View>
           </View>
 
-          <Text className="text-xs text-center text-gray-500 mt-1">
+          <Text className="text-xs text-center text-gray-500 mt-1 mb-4">
             300 EXP TILL LEVEL
           </Text>
         </View>

--- a/app/(tabs)/shop.tsx
+++ b/app/(tabs)/shop.tsx
@@ -282,9 +282,7 @@ const Shop = () => {
         </View>
 
         <View className="w-full  mb-5">
-          <Text className="text-xl text-gray-black font-bold mb-2">
-            WEAPONS
-          </Text>
+          <Text className="text-xl text-grayDark font-bold mb-2">WEAPONS</Text>
           <FlatList
             data={filterItemsByTypeAndSortByCost(items, ItemType.WEAPON)}
             renderItem={({ item }) => (
@@ -305,7 +303,7 @@ const Shop = () => {
         </View>
 
         <View className="w-full  mb-5">
-          <Text className="text-xl text-gray-black font-bold mb-2">ARMORS</Text>
+          <Text className="text-xl text-grayDark font-bold mb-2">ARMORS</Text>
           <FlatList
             data={filterItemsByTypeAndSortByCost(items, ItemType.ARMOR)}
             renderItem={({ item }) => (
@@ -325,7 +323,7 @@ const Shop = () => {
         </View>
 
         <View className="w-full  mb-5">
-          <Text className="text-xl text-gray-black font-bold mb-2">
+          <Text className="text-xl text-grayDark font-bold mb-2">
             ACCESSORIES
           </Text>
           <FlatList
@@ -347,9 +345,7 @@ const Shop = () => {
         </View>
 
         <View className="w-full  mb-5">
-          <Text className="text-xl text-gray-black font-bold mb-2">
-            POTIONS
-          </Text>
+          <Text className="text-xl text-grayDark font-bold mb-2">POTIONS</Text>
           <View className="flex-row gap-3">
             <FlatList
               data={filterItemsByTypeAndSortByCost(

--- a/app/(tabs)/social.tsx
+++ b/app/(tabs)/social.tsx
@@ -6,8 +6,9 @@ import {
   PanResponder,
   Animated,
   Alert,
+  RefreshControl,
 } from 'react-native';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Friend } from '@/types/social';
 import { Ionicons } from '@expo/vector-icons';
@@ -49,25 +50,24 @@ const Social = () => {
   const { userFriend, setFriends, setPendingRequests, setSentRequests } =
     useSocialStore();
 
-  // Fetch user friends
-  useEffect(() => {
-    const fetchUserFriends = async () => {
-      console.log('Fetching user friends');
+  const [refreshing, setRefreshing] = React.useState(false);
 
-      if (!user?.id) {
-        return;
-      }
+  const onRefresh = React.useCallback(async () => {
+    setRefreshing(true);
+    console.log('Refreshing friends list');
+    if (!user?.id) {
+      return;
+    }
 
-      // Fetch user friends
-      const userFriendsResponse = await getUserFriends(user?.id);
-      if (userFriendsResponse.success && userFriendsResponse.data) {
-        setFriends(userFriendsResponse.data.friends);
-        setPendingRequests(userFriendsResponse.data.pendingRequests);
-        setSentRequests(userFriendsResponse.data.sentRequests);
-      }
-    };
+    // Fetch user friends
+    const userFriendsResponse = await getUserFriends(user?.id);
+    if (userFriendsResponse.success && userFriendsResponse.data) {
+      setFriends(userFriendsResponse.data.friends);
+      setPendingRequests(userFriendsResponse.data.pendingRequests);
+      setSentRequests(userFriendsResponse.data.sentRequests);
+    }
 
-    fetchUserFriends();
+    setRefreshing(false);
   }, []);
 
   const modalData: {
@@ -504,6 +504,9 @@ const Social = () => {
         }
         ListFooterComponent={<View className="h-[10px]" />}
         showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        }
       />
     </SafeAreaView>
   );

--- a/app/(tabs)/social.tsx
+++ b/app/(tabs)/social.tsx
@@ -273,7 +273,7 @@ const Social = () => {
     if (item.key === 'sentRequests') {
       return (
         <View className="mb-5">
-          <Text className="text-xl text-gray-dark font-bold mb-2">
+          <Text className="text-xl text-grayDark font-bold mb-2">
             {item.title}
           </Text>
           <FlatList
@@ -299,7 +299,7 @@ const Social = () => {
     } else if (item.key === 'pendingRequests') {
       return (
         <View className="mb-5">
-          <Text className="text-xl text-gray-dark font-bold mb-2">
+          <Text className="text-xl text-grayDark font-bold mb-2">
             {item.title}
           </Text>
           <FlatList
@@ -323,7 +323,7 @@ const Social = () => {
       return (
         <View className="mb-5">
           <View className="w-full flex-row justify-between items-center">
-            <Text className="text-xl text-gray-dark font-bold mb-2">
+            <Text className="text-xl text-grayDark font-bold mb-2">
               {item.title}
             </Text>
             <TouchableOpacity


### PR DESCRIPTION
### Description
Implement refresh control in social. When swiping down in social screen, latest user data is fetched so user can see latest requests and friends.

### List of changes
- Update features section in README
- Remove gold in user items in profile screen (user already bought it so no need to display it again)
- Implement refresh control in social screen
- Implement optimistic updates on social screen

### Did you install additional dependencies?
- [ ] Yes

### Which part of the repository does your PR affect?
- [ ] Sign In
- [ ] Sign Up
- [ ] Onboarding
- [x] Profile
- [ ] Workout
- [ ] Quest
- [x] Shop
- [x] Social
- [ ] Assets
- [ ] Project Structure
- [x] Other. If so, specify: README