### PR TITLE
Fix: Import of purchaseItem from default to named in shop screen

### DIFF
--- a/app/(tabs)/shop.tsx
+++ b/app/(tabs)/shop.tsx
@@ -18,7 +18,7 @@ import {
 import clsx from 'clsx';
 import FQModal from '@/components/FQModal';
 import { useUserStore } from '@/store/user';
-import purchaseItem from '@/services/item';
+import { purchaseItem } from '@/services/item';
 import { useItemStore } from '@/store/item';
 import { BASE_ITEM } from '@/constants/item';
 import { Sprite } from '@/components/Sprite';


### PR DESCRIPTION
### Description
Fix import of purchaseItem from default to named in shop screen

### List of changes
- Fix incorrect default import of purchaseItem which doesn't exist and now is a named import.

### Did you install additional dependencies?
- [ ] Yes

### Which part of the repository does your PR affect?
- [ ] Sign In
- [ ] Sign Up
- [ ] Onboarding
- [ ] Profile
- [ ] Workout
- [ ] Quest
- [x] Shop
- [ ] Social
- [ ] Assets
- [ ] Report
- [ ] Project Structure
- [ ] Other. If so, specify: