### PR TITLE
Feat: Level up after workout and assign attribute points

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -639,16 +639,9 @@ const Profile = () => {
         setVisible={setIsSettingsVisible}
         title="Profile Settings"
         onConfirm={handleUpdateProfile}
+        closeButton
       >
         <View className="py-4 w-[220px] relative">
-          {/* Close Button */}
-          <TouchableOpacity
-            onPress={() => setIsSettingsVisible(false)}
-            style={{ position: 'absolute', top: 2, right: 2 }}
-          >
-            <Ionicons name="close" size={24} color="#000" />
-          </TouchableOpacity>
-
           <View className="space-y-4 mt-4">
             <View>
               <Text className="text-gray-500 mb-1">Username</Text>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -5,10 +5,11 @@ import {
   ScrollView,
   Alert,
   TextInput,
+  DimensionValue,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import FQModal from '@/components/FQModal';
 import { Item, ItemType } from '@/types/item';
 import { updateUserProfile } from '@/services/user';
@@ -20,6 +21,7 @@ import { AnimatedSpriteID, SpriteID, SpriteState } from '@/constants/sprite';
 import { Sprite } from '@/components/Sprite';
 import { AnimatedSprite } from '@/components/AnimatedSprite';
 import clsx from 'clsx';
+import { getUserExpThreshold } from '@/utils/user';
 
 interface ItemCardProps {
   item: Item;
@@ -110,6 +112,18 @@ const Profile = () => {
   const isItemEquipped = selectedItem
     ? user?.equippedItems.includes(selectedItem.id)
     : false;
+
+  const userExpTillLevelUp = useMemo(() => {
+    if (!user) return 0;
+
+    return getUserExpThreshold(user) - user.exp;
+  }, [user]);
+
+  const userExpBarWidth: DimensionValue = useMemo(() => {
+    if (!user) return `0%`;
+
+    return `${(user.exp / getUserExpThreshold(user)) * 100}%` as DimensionValue;
+  }, [user]);
 
   // Calculate total stats based on user profile and equipped items
   useEffect(() => {
@@ -495,19 +509,22 @@ const Profile = () => {
           </View>
         </View>
 
-        {/*
         <View className="mb-4">
           <View className="border border-gray rounded">
             <View className="w-full h-2 bg-gray-200 rounded">
-              <View className="w-1/3 h-full bg-yellow rounded" />
+              <View
+                className="h-full bg-yellow rounded"
+                style={{
+                  width: userExpBarWidth,
+                }}
+              />
             </View>
           </View>
 
           <Text className="text-xs text-center text-gray-500 mt-1 mb-4">
-            300 EXP TILL LEVEL 10
+            {userExpTillLevelUp} EXP TILL LEVEL UP
           </Text>
         </View>
-        */}
 
         {/* Attributes Section */}
         <View className="text-lg mb-6">

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -22,6 +22,8 @@ import { Sprite } from '@/components/Sprite';
 import { AnimatedSprite } from '@/components/AnimatedSprite';
 import clsx from 'clsx';
 import { getUserExpThreshold } from '@/utils/user';
+import { router } from 'expo-router';
+import { Colors } from '@/constants/colors';
 
 interface ItemCardProps {
   item: Item;
@@ -510,10 +512,10 @@ const Profile = () => {
         </View>
 
         <View className="mb-4">
-          <View className="border border-gray rounded">
+          <View className="w-full border border-gray rounded">
             <View className="w-full h-2 bg-gray-200 rounded">
               <View
-                className="h-full bg-yellow rounded"
+                className="h-full w-full bg-yellow border border-yellow rounded"
                 style={{
                   width: userExpBarWidth,
                 }}
@@ -528,9 +530,17 @@ const Profile = () => {
 
         {/* Attributes Section */}
         <View className="text-lg mb-6">
-          <Text className="font-bold text-xl text-grayDark mb-2">
-            ATTRIBUTES
-          </Text>
+          <View className="mb-2 flex-row items-center">
+            <Text className="font-bold text-xl text-grayDark mr-2">
+              ATTRIBUTES
+            </Text>
+            <TouchableOpacity
+              onPress={() => router.push('/allocate-points')}
+              className="ml-2"
+            >
+              <Ionicons name="add-outline" size={30} color={Colors.blue} />
+            </TouchableOpacity>
+          </View>
           <View className="space-y-2">
             <View className="flex-row justify-between items-center">
               <Text className="text-lg text-gray-500">

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -74,6 +74,7 @@ export default function RootLayout() {
       <Stack.Screen name="(onboarding)" options={{ headerShown: false }} />
       <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
       <Stack.Screen name="index" options={{ headerShown: false }} />
+      <Stack.Screen name="allocate-points" options={{ headerShown: false }} />
       <Stack.Screen name="fight" options={{ headerShown: false }} />
       <Stack.Screen name="+not-found" />
     </Stack>

--- a/app/allocate-points.tsx
+++ b/app/allocate-points.tsx
@@ -1,0 +1,298 @@
+import FQButton from '@/components/FQButton';
+import FQModal from '@/components/FQModal';
+import { Colors } from '@/constants/colors';
+import { updateUserProfile } from '@/services/user';
+import { useUserStore } from '@/store/user';
+import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  SafeAreaView,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+const AllocatePoints = () => {
+  const [currentPoints, setCurrentPoints] = useState(0);
+  const [attributes, setAttributes] = useState({
+    power: 0,
+    speed: 0,
+    health: 0,
+  });
+
+  const [confirmModalVisible, setConfirmModalVisible] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const { user, setUser } = useUserStore();
+
+  const baseAttributes = useMemo(() => {
+    if (!user)
+      return {
+        power: 0,
+        speed: 0,
+        health: 0,
+      };
+
+    return user?.attributes;
+  }, [user]);
+
+  useEffect(() => {
+    if (!user) return;
+
+    setCurrentPoints(user.attributePoints);
+    setAttributes(user.attributes);
+  }, [user]);
+
+  const handleConfirmAllocation = async () => {
+    if (!user) return;
+
+    const oldUser = user;
+
+    setLoading(true);
+
+    // Update user attributes
+    const updateUserProfileResponse = await updateUserProfile(user?.id, {
+      attributes,
+      attributePoints: currentPoints,
+    });
+
+    setLoading(false);
+
+    if (!updateUserProfileResponse.success) {
+      Alert.alert('Error', 'Failed to update attributes');
+
+      setUser(oldUser);
+      return;
+    }
+
+    setUser({
+      ...user,
+      attributes,
+      attributePoints: currentPoints,
+    });
+
+    router.replace('/profile');
+  };
+
+  return (
+    <SafeAreaView className="relative w-full h-full px-10 py-8 justify-center items-center">
+      <FQModal
+        visible={confirmModalVisible}
+        setVisible={setConfirmModalVisible}
+        title="Allocate points"
+        onConfirm={handleConfirmAllocation}
+        width={250}
+        cancelText="CANCEL"
+      >
+        <Text className="my-2">
+          Are you sure you want to allocate these points?
+        </Text>
+      </FQModal>
+      <View className="w-full">
+        <View className="w-full items-center mb-10">
+          <Text className="mb-2 text-lg font-medium">You have</Text>
+          <Text className="text-4xl font-bold mb-2">
+            {currentPoints} {currentPoints === 1 ? 'point' : 'points'}
+          </Text>
+          <Text className="mb-2 text-lg font-medium">to allocate</Text>
+        </View>
+
+        <View className="justify-center items-center mb-10">
+          {/* POWER */}
+          <View className="w-full flex-row justify-between items-center mb-5">
+            <View className="flex-row justify-start items-center">
+              <Text className="text-2xl font-medium">Power: </Text>
+              <Text className="text-2xl font-bold">{attributes.power}</Text>
+            </View>
+            <View className="flex-row items-center justify-center">
+              {attributes.power > baseAttributes.power ? (
+                <TouchableOpacity
+                  className="w-[35px] h-[30px] items-center"
+                  onPress={() => {
+                    setAttributes({
+                      ...attributes,
+                      power: attributes.power - 1,
+                    });
+                    setCurrentPoints(currentPoints + 1);
+                  }}
+                >
+                  <Ionicons name="remove" size={30} color={'red'} />
+                </TouchableOpacity>
+              ) : (
+                <View className="w-[35px]" />
+              )}
+              {currentPoints > 0 ? (
+                <TouchableOpacity
+                  className="w-[35px] h-[30px] items-center mr-2"
+                  onPress={() => {
+                    setAttributes({
+                      ...attributes,
+                      power: attributes.power + 1,
+                    });
+                    setCurrentPoints(currentPoints - 1);
+                  }}
+                >
+                  <Ionicons name="add-outline" size={30} color={Colors.blue} />
+                </TouchableOpacity>
+              ) : (
+                <View className="w-[35px] mr-2" />
+              )}
+              <TouchableOpacity
+                onPress={() =>
+                  Alert.alert(
+                    'Power',
+                    'This attribute determines how strong your attacks are.',
+                  )
+                }
+              >
+                <Ionicons
+                  name="information-circle-outline"
+                  size={25}
+                  className=""
+                />
+              </TouchableOpacity>
+            </View>
+          </View>
+
+          {/* SPEED */}
+          <View className="w-full flex-row justify-between items-center mb-5">
+            <View className="flex-row justify-start items-center">
+              <Text className="text-2xl font-medium">Speed: </Text>
+              <Text className="text-2xl font-bold">{attributes.speed}</Text>
+            </View>
+            <View className="flex-row items-center justify-center">
+              {attributes.speed > baseAttributes.speed ? (
+                <TouchableOpacity
+                  className="w-[35px] h-[30px] items-center"
+                  onPress={() => {
+                    setAttributes({
+                      ...attributes,
+                      speed: attributes.speed - 1,
+                    });
+                    setCurrentPoints(currentPoints + 1);
+                  }}
+                >
+                  <Ionicons name="remove" size={30} color={'red'} />
+                </TouchableOpacity>
+              ) : (
+                <View className="w-[35px]" />
+              )}
+              {currentPoints > 0 ? (
+                <TouchableOpacity
+                  className="w-[35px] h-[30px] items-center mr-2"
+                  onPress={() => {
+                    setAttributes({
+                      ...attributes,
+                      speed: attributes.speed + 1,
+                    });
+                    setCurrentPoints(currentPoints - 1);
+                  }}
+                >
+                  <Ionicons name="add-outline" size={30} color={Colors.blue} />
+                </TouchableOpacity>
+              ) : (
+                <View className="w-[35px] mr-2" />
+              )}
+              <TouchableOpacity
+                onPress={() =>
+                  Alert.alert(
+                    'Speed',
+                    'This attribute determines how fast you get to your turn.',
+                  )
+                }
+              >
+                <Ionicons
+                  name="information-circle-outline"
+                  size={25}
+                  className=""
+                />
+              </TouchableOpacity>
+            </View>
+          </View>
+          <View className="w-full flex-row justify-between items-center mb-5">
+            <View className="flex-row justify-start items-center">
+              <Text className="text-2xl font-medium">Health: </Text>
+              <Text className="text-2xl font-bold">{attributes.health}</Text>
+            </View>
+            <View className="flex-row items-center justify-center">
+              {attributes.health > baseAttributes.health ? (
+                <TouchableOpacity
+                  className="w-[35px] h-[30px] items-center"
+                  onPress={() => {
+                    setAttributes({
+                      ...attributes,
+                      health: attributes.health - 1,
+                    });
+                    setCurrentPoints(currentPoints + 1);
+                  }}
+                >
+                  <Ionicons name="remove" size={30} color={'red'} />
+                </TouchableOpacity>
+              ) : (
+                <View className="w-[35px]" />
+              )}
+              {currentPoints > 0 ? (
+                <TouchableOpacity
+                  className="w-[35px] h-[30px] items-center mr-2"
+                  onPress={() => {
+                    setAttributes({
+                      ...attributes,
+                      health: attributes.health + 1,
+                    });
+                    setCurrentPoints(currentPoints - 1);
+                  }}
+                >
+                  <Ionicons name="add-outline" size={30} color={Colors.blue} />
+                </TouchableOpacity>
+              ) : (
+                <View className="w-[35px] mr-2" />
+              )}
+              <TouchableOpacity
+                onPress={() =>
+                  Alert.alert(
+                    'Health',
+                    'This attribute determines how much health you have.',
+                  )
+                }
+              >
+                <Ionicons
+                  name="information-circle-outline"
+                  size={25}
+                  className=""
+                />
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+
+        <FQButton
+          onPress={() => {
+            setConfirmModalVisible(true);
+          }}
+          className="mb-5"
+          disabled={currentPoints === user?.attributePoints || loading}
+        >
+          {loading ? (
+            <View className="h-full justify-center items-center">
+              <ActivityIndicator size="small" color="white" />
+            </View>
+          ) : (
+            'ALLOCATE'
+          )}
+        </FQButton>
+        <FQButton
+          onPress={() => router.back()}
+          className="mb-5"
+          secondary
+          disabled={loading}
+        >
+          BACK
+        </FQButton>
+      </View>
+    </SafeAreaView>
+  );
+};
+export default AllocatePoints;

--- a/components/AnimatedSprite.tsx
+++ b/components/AnimatedSprite.tsx
@@ -174,6 +174,12 @@ export const AnimatedSprite: FC<IAnimatedSprite> = ({
       switch (state) {
         case SpriteState.ATTACK_1:
           return 2;
+        case SpriteState.ATTACK_2:
+          return 3;
+        case SpriteState.ATTACK_3:
+          return 4;
+        case SpriteState.ATTACK_4:
+          return 5;
         case SpriteState.DAMAGED:
           return 8;
         case SpriteState.DEATH:

--- a/components/FQModal.tsx
+++ b/components/FQModal.tsx
@@ -1,5 +1,6 @@
 import { View, Text, Modal, TouchableOpacity } from 'react-native';
 import React, { FC } from 'react';
+import { Ionicons } from '@expo/vector-icons';
 
 interface IFQModal {
   title: string;
@@ -14,6 +15,7 @@ interface IFQModal {
 
   cancelText?: string;
   confirmText?: string;
+  closeButton?: boolean;
 }
 
 const FQModal: FC<IFQModal> = ({
@@ -27,6 +29,7 @@ const FQModal: FC<IFQModal> = ({
   onCancel,
   cancelText,
   confirmText,
+  closeButton = false,
 }) => {
   if (!visible) {
     return null;
@@ -57,12 +60,19 @@ const FQModal: FC<IFQModal> = ({
           style={{ width: width }}
         >
           <View>
-            <Text
-              className="text-xl text-black font-bold"
-              testID="FQButton-title"
-            >
-              {title}
-            </Text>
+            <View className="flex-row justify-between items-center">
+              <Text
+                className="text-xl text-black font-bold"
+                testID="FQButton-title"
+              >
+                {title}
+              </Text>
+              {closeButton && (
+                <TouchableOpacity onPress={handleCancel}>
+                  <Ionicons name="close" size={24} color="#000" />
+                </TouchableOpacity>
+              )}
+            </View>
             {subtitle && (
               <Text
                 className="text-black font-medium"

--- a/constants/sprite.ts
+++ b/constants/sprite.ts
@@ -31,6 +31,7 @@ export enum SpriteState {
   ATTACK_1 = 'attack_1',
   ATTACK_2 = 'attack_2',
   ATTACK_3 = 'attack_3',
+  ATTACK_4 = 'attack_4',
   DAMAGED = 'damaged',
   DEATH = 'death',
 }

--- a/services/workout.ts
+++ b/services/workout.ts
@@ -33,15 +33,17 @@ export const updateEXP: (
       throw new Error('User data not found.');
     }
 
+    const expGain = duration * 1000;
+
     // Get new user exp amount
-    const userAfterExpGain = updateUserAfterExpGain(userData, duration);
+    const userAfterExpGain = updateUserAfterExpGain(userData, expGain);
 
     await updateDoc(userRef, {
       exp: userAfterExpGain.exp,
       attributePoints: userAfterExpGain.attributePoints,
     });
 
-    console.log('exp successfully incremented by ' + duration + 'xp.');
+    console.log('exp successfully incremented by ' + expGain + 'xp.');
 
     return {
       data: null,

--- a/services/workout.ts
+++ b/services/workout.ts
@@ -2,6 +2,7 @@ import { doc, getDoc, updateDoc, collection } from 'firebase/firestore';
 import { FIREBASE_DB } from '@/firebaseConfig';
 import { APIResponse } from '@/types/general';
 import { userConverter } from './user';
+import { updateUserAfterExpGain } from '@/utils/workout';
 
 // Function to handle the updating of exp
 /**
@@ -33,8 +34,12 @@ export const updateEXP: (
     }
 
     // Get new user exp amount
-    const newEXP = userData.exp + duration;
-    await updateDoc(userRef, { exp: newEXP });
+    const userAfterExpGain = updateUserAfterExpGain(userData, duration);
+
+    await updateDoc(userRef, {
+      exp: userAfterExpGain.exp,
+      attributePoints: userAfterExpGain.attributePoints,
+    });
 
     console.log('exp successfully incremented by ' + duration + 'xp.');
 

--- a/tests/components/__tests__/FQModal.test.tsx
+++ b/tests/components/__tests__/FQModal.test.tsx
@@ -1,7 +1,11 @@
-import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import FQModal from '@/components/FQModal';
 import { Text } from 'react-native';
+
+// Mock Ionicons
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: '',
+}));
 
 describe('FQModal', () => {
   const mockSetVisible = jest.fn();

--- a/tests/utils/__tests__/user.test.ts
+++ b/tests/utils/__tests__/user.test.ts
@@ -1,0 +1,119 @@
+import { BASE_USER } from '@/constants/user';
+import { User } from '@/types/user';
+import { getUserExpThreshold } from '@/utils/user';
+
+describe('User Utility Functions', () => {
+  describe('getUserExpThreshold', () => {
+    it('should return the correct exp threshold #1', () => {
+      const user: User = {
+        ...BASE_USER,
+        attributes: {
+          power: 5,
+          speed: 5,
+          health: 5,
+        },
+        attributePoints: 0,
+      };
+
+      const expThreshold = getUserExpThreshold(user);
+
+      expect(expThreshold).toBe(4000);
+    });
+
+    it('should return the correct exp threshold #2', () => {
+      const user: User = {
+        ...BASE_USER,
+        attributes: {
+          power: 5,
+          speed: 5,
+          health: 5,
+        },
+        attributePoints: 1,
+      };
+
+      const expThreshold = getUserExpThreshold(user);
+
+      expect(expThreshold).toBe(4200);
+    });
+
+    it('should return the correct exp threshold #3', () => {
+      const user: User = {
+        ...BASE_USER,
+        attributes: {
+          power: 6,
+          speed: 6,
+          health: 6,
+        },
+        attributePoints: 1,
+      };
+
+      const expThreshold = getUserExpThreshold(user);
+
+      expect(expThreshold).toBe(4800);
+    });
+
+    it('should return the correct exp threshold #4', () => {
+      const user: User = {
+        ...BASE_USER,
+        attributes: {
+          power: 6,
+          speed: 6,
+          health: 6,
+        },
+        attributePoints: 2,
+      };
+
+      const expThreshold = getUserExpThreshold(user);
+
+      expect(expThreshold).toBe(5000);
+    });
+
+    it('should return the correct exp threshold #5', () => {
+      const user: User = {
+        ...BASE_USER,
+        attributes: {
+          power: 10,
+          speed: 10,
+          health: 10,
+        },
+        attributePoints: 5,
+      };
+
+      const expThreshold = getUserExpThreshold(user);
+
+      expect(expThreshold).toBe(8000);
+    });
+
+    it('should return the correct exp threshold #6', () => {
+      const user: User = {
+        ...BASE_USER,
+        attributes: {
+          power: 20,
+          speed: 20,
+          health: 20,
+        },
+        attributePoints: 0,
+      };
+
+      const expThreshold = getUserExpThreshold(user);
+
+      expect(expThreshold).toBe(13000);
+    });
+
+    it('should return the correct exp threshold #7', () => {
+      const user: User = {
+        ...BASE_USER,
+        attributes: {
+          power: 40,
+          speed: 40,
+          health: 40,
+        },
+        attributePoints: 0,
+      };
+
+      const expThreshold = getUserExpThreshold(user);
+
+      expect(expThreshold).toBe(25000);
+    });
+  });
+});

--- a/tests/utils/__tests__/workout.test.ts
+++ b/tests/utils/__tests__/workout.test.ts
@@ -1,0 +1,98 @@
+import { BASE_USER } from '@/constants/user';
+import { User } from '@/types/user';
+import { updateUserAfterExpGain } from '@/utils/workout';
+
+describe('Workout Utility Functions', () => {
+  describe('updateUserAfterExpGain', () => {
+    it('should update user exp #1', () => {
+      const user1: User = {
+        ...BASE_USER,
+        exp: 0,
+      };
+
+      const updatedUser1 = updateUserAfterExpGain(user1, 1000);
+
+      expect(updatedUser1.exp).toBe(1000);
+    });
+
+    it('should update user exp #2', () => {
+      const user1: User = {
+        ...BASE_USER,
+        exp: 1000,
+      };
+
+      const updatedUser1 = updateUserAfterExpGain(user1, 1000);
+
+      expect(updatedUser1.exp).toBe(2000);
+    });
+
+    it('should update user exp #3', () => {
+      const user1: User = {
+        ...BASE_USER,
+        exp: 2000,
+      };
+
+      const updatedUser1 = updateUserAfterExpGain(user1, 1000);
+
+      expect(updatedUser1.exp).toBe(3000);
+    });
+
+    it('should level up a user and give them attribute points #1', () => {
+      const user1: User = {
+        ...BASE_USER,
+        exp: 3000,
+      };
+
+      const updatedUser1 = updateUserAfterExpGain(user1, 1000);
+
+      expect(updatedUser1.exp).toBe(0);
+      expect(updatedUser1.attributePoints).toBe(1);
+    });
+
+    it('should level up a user and give them attribute points #1', () => {
+      const user1: User = {
+        ...BASE_USER,
+        exp: 3000,
+      };
+
+      const updatedUser1 = updateUserAfterExpGain(user1, 2000);
+
+      expect(updatedUser1.exp).toBe(1000);
+      expect(updatedUser1.attributePoints).toBe(1);
+    });
+
+    it('should level up a user and give them attribute points #2', () => {
+      const user1: User = {
+        ...BASE_USER,
+        exp: 3000,
+      };
+
+      const updatedUser1 = updateUserAfterExpGain(user1, 3000);
+
+      expect(updatedUser1.exp).toBe(2000);
+      expect(updatedUser1.attributePoints).toBe(1);
+    });
+
+    it('should level up a user and give them attribute points multiple times #1', () => {
+      const user1: User = {
+        ...BASE_USER,
+        exp: 0,
+      };
+
+      const updatedUser1 = updateUserAfterExpGain(user1, 9000);
+
+      expect(updatedUser1.attributePoints).toBe(2);
+    });
+
+    it('should level up a user and give them attribute points multiple times #2', () => {
+      const user1: User = {
+        ...BASE_USER,
+        exp: 0,
+      };
+
+      const updatedUser1 = updateUserAfterExpGain(user1, 15000);
+
+      expect(updatedUser1.attributePoints).toBe(3);
+    });
+  });
+});

--- a/utils/user.ts
+++ b/utils/user.ts
@@ -1,0 +1,11 @@
+import { User } from '@/types/user';
+
+export const getUserExpThreshold = (user: User) => {
+  return (
+    1000 + // Base exp
+    user.attributes.power * 200 +
+    user.attributes.speed * 200 +
+    user.attributes.health * 200 +
+    user.attributePoints * 200
+  );
+};

--- a/utils/workout.ts
+++ b/utils/workout.ts
@@ -1,3 +1,6 @@
+import { User } from '@/types/user';
+import { getUserExpThreshold } from './user';
+
 /* converts seconds to xminutes xseconds so for display purposes*/
 export const secondsToMinutes = (seconds: number) => {
   return Math.floor(seconds / 60) + 'm' + (seconds % 60) + 's';
@@ -7,3 +10,27 @@ export const addToTemplate = () => {};
 export const removeFromTemplate = () => {};
 export const submitTemplate = () => {};
 export const resetTemplate = () => {};
+
+export const updateUserAfterExpGain = (user: User, expGain: number): User => {
+  // Check if user's exp is enough to level up
+
+  const newUser: User = { ...user };
+  let exp = user.exp + expGain;
+
+  let expThreshold = getUserExpThreshold(newUser);
+
+  if (exp < expThreshold) {
+    newUser.exp = exp;
+    return newUser;
+  }
+
+  while (exp >= expThreshold) {
+    // Level up
+    newUser.attributePoints += 1;
+    exp -= expThreshold;
+    newUser.exp = exp;
+    expThreshold = getUserExpThreshold(newUser);
+  }
+
+  return newUser;
+};


### PR DESCRIPTION
### Description
Implement levelling up after workout and assigning attribute points in profile screen

### List of changes
- Gaining exp past user exp threshold now levels user and gives them an attribute point to allocate
- Exp gain for each second of working out is now 1000x from before for testing purposes
- Users can now allocate their attribute points through the profile screen
- Add close button property in FQModal

![image](https://github.com/user-attachments/assets/4f83834b-adf2-409e-9134-829c48b2fd02)
![image](https://github.com/user-attachments/assets/9df0a617-f30f-4cc0-9943-b33a133749b5)
![image](https://github.com/user-attachments/assets/e35feaab-2274-4736-9c6c-c1929ca71c11)

### Did you install additional dependencies?
- [ ] Yes

### Which part of the repository does your PR affect?
- [ ] Sign In
- [ ] Sign Up
- [ ] Onboarding
- [x] Profile
- [x] Workout
- [ ] Quest
- [ ] Shop
- [ ] Social
- [ ] Assets
- [ ] Report
- [ ] Project Structure
- [ ] Other. If so, specify: