### PR TITLE
Fix profile settings modal to reset fields and sharing toggles to actual user data on close

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -484,10 +484,10 @@ const Profile = () => {
   const handleUpdateProfile = async () => {
     if (!user) return;
 
-    if (!username.trim() || username.trim().length < 3) {
+    if (!username.trim() || username.trim().length < 4) {
       Alert.alert(
         'Validation Error',
-        'Username must be at least 3 characters long.',
+        'Username must be at least 4 characters long.',
       );
       return;
     }

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -484,6 +484,27 @@ const Profile = () => {
   const handleUpdateProfile = async () => {
     if (!user) return;
 
+    if (!username.trim() || username.trim().length < 3) {
+      Alert.alert(
+        'Validation Error',
+        'Username must be at least 3 characters long.',
+      );
+      return;
+    }
+
+    const parsedHeight = parseFloat(height);
+    const parsedWeight = parseFloat(weight);
+
+    if (isNaN(parsedHeight) || parsedHeight <= 0) {
+      Alert.alert('Validation Error', 'Height must be a positive number.');
+      return;
+    }
+
+    if (isNaN(parsedWeight) || parsedWeight <= 0) {
+      Alert.alert('Validation Error', 'Weight must be a positive number.');
+      return;
+    }
+
     const updates = {
       profileInfo: {
         ...user.profileInfo,
@@ -511,6 +532,18 @@ const Profile = () => {
       Alert.alert('Error updating profile', response.error || '');
     }
 
+    setIsSettingsVisible(false);
+  };
+
+  const closeSettingsModal = () => {
+    // Reset the state to the user's actual profile info
+    setUsername(user?.profileInfo.username || '');
+    setHeight(user?.profileInfo.height?.toString() || '');
+    setWeight(user?.profileInfo.weight?.toString() || '');
+    setIsCurrentQuestPublic(
+      user?.privacySettings.isCurrentQuestPublic ?? false,
+    );
+    setIsLastWorkoutPublic(user?.privacySettings.isLastWorkoutPublic ?? false);
     setIsSettingsVisible(false);
   };
 
@@ -778,7 +811,7 @@ const Profile = () => {
 
       <FQModal
         visible={isSettingsVisible}
-        setVisible={setIsSettingsVisible}
+        setVisible={closeSettingsModal}
         title="Profile Settings"
         onConfirm={handleUpdateProfile}
         closeButton


### PR DESCRIPTION
### Description
Updated the profile settings modal to ensure that all fields and sharing toggles reset to the actual user data when the modal is closed, preventing the display of previously entered values. This change addresses GitHub issue #11/19 regarding validation and data persistence in the profile edit functionality.

### List of changes
- Implemented state reset for username, height, weight, and sharing toggles in the closeSettingsModal function
- Added validation to ensure username is at least 3 characters long and that height and weight are positive numbers

### Did you install additional dependencies?
- [ ] Yes

### Which part of the repository does your PR affect?
- [ ] Sign In
- [ ] Sign Up
- [ ] Onboarding
- [X] Profile
- [ ] Workout
- [ ] Quest
- [ ] Shop
- [ ] Social
- [ ] Assets
- [ ] Report
- [ ] Project Structure
- [ ] Other. If so, specify: