### PR TITLE
prevent success message when no changes are made in profile update

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -485,6 +485,22 @@ const Profile = () => {
   const handleUpdateProfile = async () => {
     if (!user) return;
 
+    // Check if there are actual changes
+    const hasChanges =
+      username.trim() !== user.profileInfo.username ||
+      parseFloat(height) !== user.profileInfo.height ||
+      parseFloat(weight) !== user.profileInfo.weight ||
+      isCurrentQuestPublic !== user.privacySettings.isCurrentQuestPublic ||
+      isLastWorkoutPublic !== user.privacySettings.isLastWorkoutPublic;
+
+    if (!hasChanges) {
+      Alert.alert(
+        'No changes detected',
+        'Please make changes before confirming.',
+      );
+      return; // Exit if no changes
+    }
+
     if (!username.trim() || username.trim().length < 4) {
       Alert.alert(
         'Validation Error',


### PR DESCRIPTION
### Description
Fixes an issue where a success message was displayed even when no changes were made during the profile update process. The success message will now only appear when there are actual changes to save.

### List of changes
- Added a check to determine if any profile fields have changed before displaying the success message
- Updated the alert message to inform users when no changes are detected

### Did you install additional dependencies?
- [ ] Yes

### Which part of the repository does your PR affect?
- [ ] Sign In
- [ ] Sign Up
- [ ] Onboarding
- [X] Profile
- [ ] Workout
- [ ] Quest
- [ ] Shop
- [ ] Social
- [ ] Assets
- [ ] Report
- [ ] Project Structure
- [ ] Other. If so, specify: