### PR TITLE
revamp start and abandon buttons

### DIFF
--- a/app/(tabs)/quest.tsx
+++ b/app/(tabs)/quest.tsx
@@ -392,18 +392,16 @@ const Quest = () => {
     return (
       <TouchableOpacity
         key={index}
-        className={`bg-white p-4 px-5 mb-4 rounded text-xl shadow-sm shadow-black border border-gray h-[100px] justify-center items-between ${
-          activeQuest?.questID === item.questId ? 'opacity-50' : ''
-        }`}
+        className={`bg-white p-4 px-5 mb-4 rounded text-xl shadow-sm shadow-black border border-gray h-[100px] justify-center items-between ${activeQuest?.questID === item.questId ? 'opacity-50' : ''
+          }`}
         onPress={() => confirmAction('Start', item as Quest, setActiveQuest)}
         disabled={activeQuest?.questID === item.questId}
       >
         <View className="flex-row items-center justify-between">
           <View>
             <Text
-              className={`text-lg font-semibold ${
-                activeQuest?.questID === item.questId ? 'text-gray-500' : ''
-              }`}
+              className={`text-lg font-semibold ${activeQuest?.questID === item.questId ? 'text-gray-500' : ''
+                }`}
             >
               {item.questName}
             </Text>
@@ -447,25 +445,28 @@ const Quest = () => {
                   </Text>
                   {renderMilestoneNodes(activeQuest, activeQuest.progress)}
                   <TouchableOpacity
-                    className="absolute right-[40px] p-2"
+                    className="absolute top-[15px] right-[60px] p-2"
                     onPress={handleAdvance}
                   >
+                    <Text className="text-white text-lg bg-green px-3 py-1 rounded-lg">
+                      Start
+                    </Text>
+                    {/* 
                     <Ionicons
                       name="arrow-forward-circle-outline"
                       size={30}
-                      color="lightblue"
+                      color="green"
                     />
+                    */}
                   </TouchableOpacity>
 
                   <TouchableOpacity
-                    className="absolute right-0 p-2"
+                    className="absolute top-[15px] right-[10px] p-2"
                     onPress={handleAbandon}
                   >
-                    <Ionicons
-                      name="trash-outline"
-                      size={30}
-                      color="lightgray"
-                    />
+                    <View className="bg-red-500 rounded-full p-1">
+                      <Ionicons name="trash-outline" size={30} color="white" />
+                    </View>
                   </TouchableOpacity>
                 </View>
               ) : (

--- a/app/(tabs)/quest.tsx
+++ b/app/(tabs)/quest.tsx
@@ -440,32 +440,31 @@ const Quest = () => {
 
               {activeQuest ? (
                 <View className="bg-white p-6 rounded-xl border border-gray relative shadow-black shadow-lg min-h-[150px] max-h-[225px]">
-                  <Text className="text-lg font-semibold mb-2">
+                  <Text
+                    className="text-base font-semibold mb-2 pr-[120px]"
+                    numberOfLines={1}
+                  >
                     {activeQuest.questName}
                   </Text>
                   {renderMilestoneNodes(activeQuest, activeQuest.progress)}
+
+                  {/* Start Button */}
                   <TouchableOpacity
                     className="absolute top-[15px] right-[60px] p-2"
                     onPress={handleAdvance}
                   >
-                    <Text className="text-white text-lg bg-green px-3 py-1 rounded-lg">
-                      Start
-                    </Text>
-                    {/* 
-                    <Ionicons
-                      name="arrow-forward-circle-outline"
-                      size={30}
-                      color="green"
-                    />
-                    */}
+                    <View className="bg-green rounded-full p-2">
+                      <Ionicons name="play" size={24} color="white" />
+                    </View>
                   </TouchableOpacity>
 
+                  {/* Abandon Button */}
                   <TouchableOpacity
                     className="absolute top-[15px] right-[10px] p-2"
                     onPress={handleAbandon}
                   >
-                    <View className="bg-red-500 rounded-full p-1">
-                      <Ionicons name="trash-outline" size={30} color="white" />
+                    <View className="bg-red-500 rounded-full p-2">
+                      <Ionicons name="trash-outline" size={24} color="white" />
                     </View>
                   </TouchableOpacity>
                 </View>

--- a/app/(tabs)/quest.tsx
+++ b/app/(tabs)/quest.tsx
@@ -442,33 +442,26 @@ const Quest = () => {
 
               {activeQuest ? (
                 <View className="bg-white p-6 rounded-xl border border-gray relative shadow-black shadow-lg min-h-[150px] max-h-[225px]">
-                  <Text
-                    className="text-base font-semibold mb-2 pr-[120px]"
-                    numberOfLines={1}
-                  >
-                    {activeQuest.questName}
-                  </Text>
+                  <View className="flex-row justify-between items-center mb-2">
+                    <Text className="text-base font-semibold" numberOfLines={1}>
+                      {activeQuest.questName}
+                    </Text>
+                    <View className="flex-row justify-center items-center">
+                      {/* Start Button */}
+                      <TouchableOpacity
+                        className="mr-4"
+                        onPress={handleAdvance}
+                      >
+                        <Ionicons name="play" size={24} color="green" />
+                      </TouchableOpacity>
+
+                      {/* Abandon Button */}
+                      <TouchableOpacity className="" onPress={handleAbandon}>
+                        <Ionicons name="flag-outline" size={24} color="red" />
+                      </TouchableOpacity>
+                    </View>
+                  </View>
                   {renderMilestoneNodes(activeQuest, activeQuest.progress)}
-
-                  {/* Start Button */}
-                  <TouchableOpacity
-                    className="absolute top-[15px] right-[60px] p-2"
-                    onPress={handleAdvance}
-                  >
-                    <View className="bg-green rounded-full p-2">
-                      <Ionicons name="play" size={24} color="white" />
-                    </View>
-                  </TouchableOpacity>
-
-                  {/* Abandon Button */}
-                  <TouchableOpacity
-                    className="absolute top-[15px] right-[10px] p-2"
-                    onPress={handleAbandon}
-                  >
-                    <View className="bg-red-500 rounded-full p-2">
-                      <Ionicons name="trash-outline" size={24} color="white" />
-                    </View>
-                  </TouchableOpacity>
                 </View>
               ) : (
                 <View className="bg-gray-200 p-6 rounded-xl flex items-center justify-center min-h-[180px]">


### PR DESCRIPTION
### Description
Enhanced visibility and styling of quest control buttons by adding green background to Start button and red background to Abandon button with improved spacing between them

### List of changes
- Added green background and rounded corners to Start button
- Added red circular background to Abandon (trash) button
- Increased spacing between buttons for better visual separation

### Did you install additional dependencies?
- [ ] Yes

### Which part of the repository does your PR affect?
- [ ] Sign In
- [ ] Sign Up
- [ ] Onboarding
- [ ] Profile
- [ ] Workout
- [X] Quest
- [ ] Shop
- [ ] Social
- [ ] Assets
- [ ] Report
- [ ] Project Structure
- [ ] Other. If so, specify: