### PR TITLE
Removed optimistic updates in favor of waiting for API response

### DIFF
--- a/app/(tabs)/social.tsx
+++ b/app/(tabs)/social.tsx
@@ -448,13 +448,17 @@ const Social = () => {
       const oldSentRequests = [...sentRequests];
 
       // Optimistically add email to sent requests
-      setSentRequests([...sentRequests, modalDataOption.email]);
-      setModalVisible(false);
+      // setSentRequests([...sentRequests, modalDataOption.email]);
+      // setModalVisible(false);
 
+      // first send the request, then update the UI
       const sendFriendRequestResponse = await sendFriendRequest(
         user?.id,
         emailInput,
       );
+
+      setSentRequests([...sentRequests, modalDataOption.email]);
+      setModalVisible(false);
 
       setLoading(false);
 

--- a/app/(tabs)/social.tsx
+++ b/app/(tabs)/social.tsx
@@ -445,20 +445,11 @@ const Social = () => {
 
       setLoading(true);
 
-      const oldSentRequests = [...sentRequests];
-
-      // Optimistically add email to sent requests
-      // setSentRequests([...sentRequests, modalDataOption.email]);
-      // setModalVisible(false);
-
       // first send the request, then update the UI
       const sendFriendRequestResponse = await sendFriendRequest(
         user?.id,
         emailInput,
       );
-
-      setSentRequests([...sentRequests, modalDataOption.email]);
-      setModalVisible(false);
 
       setLoading(false);
 
@@ -470,10 +461,11 @@ const Social = () => {
           sendFriendRequestResponse.error ?? 'Error sending friend request',
         );
 
-        // Revert changes
-        setSentRequests(oldSentRequests);
         return;
       }
+
+      setSentRequests([...sentRequests, modalDataOption.email]);
+      setModalVisible(false);
 
       // Add email to sent requests
     } else if (modalDataOption.option === ModalDataOptions.REMOVE_FRIEND) {


### PR DESCRIPTION
### Description
Now validates the email first before adding anything to the sent requests list to avoid a misleading UI feedback.

### List of changes
- swapped positions of sendFriendRequestResponse and setSentRequests

### Did you install additional dependencies?
- [ ] Yes

### Which part of the repository does your PR affect?
- [ ] Sign In
- [ ] Sign Up
- [ ] Onboarding
- [ ] Profile
- [ ] Workout
- [ ] Quest
- [ ] Shop
- [X] Social
- [ ] Assets
- [ ] Report
- [ ] Project Structure
- [ ] Other. If so, specify: