### PR TITLE
Fix/progress bar

### DIFF
--- a/app/(tabs)/quest.tsx
+++ b/app/(tabs)/quest.tsx
@@ -266,7 +266,7 @@ const Quest = () => {
 
   const handleAdvance = async () => {
     if (activeQuest && user?.id) {
-      // Now checking for 30 minutes
+      // TODO: Change this to 30 minutes
       if (user.activeWorkoutMinutes < 30) {
         Alert.alert(
           'Not Strong Enough...',
@@ -360,11 +360,6 @@ const Quest = () => {
     }
   };
 
-  const calculateQuestPercentage = (quest: ActiveQuest, progress: number) => {
-    const finalMilestone = quest.milestones[quest.milestones.length - 1];
-    return Math.round((progress / finalMilestone) * 100);
-  };
-
   const renderMilestoneNodes = (quest: ActiveQuest, progress: number) => {
     const startingPoint = 'start';
     const selectedQuest = availableQuests.find(
@@ -376,25 +371,36 @@ const Quest = () => {
     const nextMilestones = getNextMilestones(selectedQuest, progress);
     const visualMilestones = [startingPoint, ...nextMilestones];
 
-    const percentage = calculateQuestPercentage(quest, progress);
+    // const percentage = calculateQuestPercentage(quest, progress);
+
+    const getProgressText = () => {
+      if (!user?.activeWorkoutMinutes) return '0% ready to advance';
+
+      if (user.activeWorkoutMinutes >= 30) {
+        return 'Ready to advance! ✨';
+      }
+
+      const readyPercentage = Math.round(
+        (user.activeWorkoutMinutes / 30) * 100,
+      );
+      return `${readyPercentage}% ready to advance`;
+    };
 
     return (
-      <View className="mt-6 mb-4">
-        <Text className="text-base text-gray-600 mb-3">
-          Progress: {percentage}%
-        </Text>
+      <View className="mt-4 mb-2">
+        <Text className="text-sm text-gray-600 mb-2">{getProgressText()}</Text>
 
         <View
           className="flex-row justify-between items-center relative"
-          style={{ height: 60 }}
+          style={{ height: 50 }}
         >
           <View
             className="absolute bg-gray"
             style={{
-              height: 2,
+              height: 3,
               width: '100%',
               top: '50%',
-              transform: [{ translateY: -1 }],
+              transform: [{ translateY: -1.5 }],
             }}
           />
 
@@ -410,23 +416,30 @@ const Quest = () => {
                 className="items-center"
               >
                 {isBossNode ? (
-                  <View style={{ width: 70, height: 120 }}>
+                  <View
+                    style={{
+                      width: 60,
+                      height: 60,
+                      marginTop: -50,
+                      marginLeft: -20,
+                    }}
+                  >
                     <AnimatedSprite
                       id={activeQuest?.boss.spriteId}
-                      width={85}
-                      height={85}
+                      width={80}
+                      height={80}
                       state={SpriteState.IDLE}
                     />
                   </View>
                 ) : (
                   <View
                     style={{
-                      width: 24,
-                      height: 24,
-                      borderRadius: 12,
+                      width: 20,
+                      height: 20,
+                      borderRadius: 20,
                       backgroundColor: isCompleted ? '#4CAF50' : '#D3D3D3',
                       borderWidth: 2,
-                      borderColor: isCompleted ? '#388E3C' : '#404040',
+                      borderColor: isCompleted ? '#45a049' : '#c0c0c0',
                     }}
                   />
                 )}

--- a/app/(tabs)/quest.tsx
+++ b/app/(tabs)/quest.tsx
@@ -266,8 +266,8 @@ const Quest = () => {
 
   const handleAdvance = async () => {
     if (activeQuest && user?.id) {
-      // TODO: Change this to 30 minutes
-      if (user.activeWorkoutMinutes < 10) {
+      // Now checking for 30 minutes
+      if (user.activeWorkoutMinutes < 30) {
         Alert.alert(
           'Not Strong Enough...',
           "You'll need to train more before challenging this foe. Return after training!",
@@ -292,13 +292,13 @@ const Quest = () => {
 
         try {
           const result = await updateUserProfile(user.id, {
-            activeWorkoutMinutes: user.activeWorkoutMinutes - 1800,
+            activeWorkoutMinutes: user.activeWorkoutMinutes - 30,
           });
 
           if (result.success) {
             setUser({
               ...user,
-              activeWorkoutMinutes: user.activeWorkoutMinutes - 1800,
+              activeWorkoutMinutes: user.activeWorkoutMinutes - 30,
             });
 
             router.replace({
@@ -385,13 +385,24 @@ const Quest = () => {
         </Text>
 
         <View
-          className="flex-row justify-between items-center"
+          className="flex-row justify-between items-center relative"
           style={{ height: 60 }}
         >
+          <View
+            className="absolute bg-gray"
+            style={{
+              height: 2,
+              width: '100%',
+              top: '50%',
+              transform: [{ translateY: -1 }],
+            }}
+          />
+
           {visualMilestones.map((milestone) => {
             const milestoneValue =
               milestone === 'start' ? 0 : Number(milestone);
             const isBossNode = milestoneValue === Number(quest.bossThreshold);
+            const isCompleted = progress >= milestoneValue;
 
             return (
               <View
@@ -413,9 +424,9 @@ const Quest = () => {
                       width: 24,
                       height: 24,
                       borderRadius: 12,
-                      backgroundColor: '#D3D3D3',
+                      backgroundColor: isCompleted ? '#4CAF50' : '#D3D3D3',
                       borderWidth: 2,
-                      borderColor: '#404040',
+                      borderColor: isCompleted ? '#388E3C' : '#404040',
                     }}
                   />
                 )}

--- a/app/(tabs)/quest.tsx
+++ b/app/(tabs)/quest.tsx
@@ -374,21 +374,21 @@ const Quest = () => {
     // const percentage = calculateQuestPercentage(quest, progress);
 
     const getProgressText = () => {
-      if (!user?.activeWorkoutMinutes) return '0% ready to advance';
+      if (!user?.activeWorkoutMinutes) return '0% ready to advance!';
 
       if (user.activeWorkoutMinutes >= 30) {
-        return 'Ready to advance! ✨';
+        return 'Ready to advance!';
       }
 
       const readyPercentage = Math.round(
         (user.activeWorkoutMinutes / 30) * 100,
       );
-      return `${readyPercentage}% ready to advance`;
+      return `${readyPercentage}% ready to advance!`;
     };
 
     return (
       <View className="mt-4 mb-2">
-        <Text className="text-sm text-gray-600 mb-2">{getProgressText()}</Text>
+        <Text className="text-md mb-5 font-bold">{getProgressText()}</Text>
 
         <View
           className="flex-row justify-between items-center relative"

--- a/app/fight.tsx
+++ b/app/fight.tsx
@@ -627,14 +627,17 @@ const Combat = () => {
     if (isMonsterInitialized && player && monster) {
       const initialTurns = calculateTurnOrder(player.speed, monster.speed);
       setTurnQueue(initialTurns);
+    } else if (isBossFight && player && monster) {
+      const initialTurns = calculateTurnOrder(player.speed, monster.speed);
+      setTurnQueue(initialTurns);
     }
-  }, [isMonsterInitialized, player, monster]);
+  }, [isMonsterInitialized, player, monster, isBossFight]);
 
   const handleMonsterTurn = async () => {
     if (
       isAnimating ||
       turnQueue[currentTurnIndex]?.isPlayer ||
-      !isMonsterInitialized
+      (!isMonsterInitialized && !isBossFight)
     )
       return;
 

--- a/app/fight.tsx
+++ b/app/fight.tsx
@@ -17,10 +17,11 @@ import { AnimatedSpriteID, SpriteState } from '@/constants/sprite';
 import { AnimatedSprite } from '@/components/AnimatedSprite';
 import { StatusBar } from 'expo-status-bar';
 import { useUserStore } from '@/store/user';
-import { getRandomMonster } from '@/services/monster';
+// import { getRandomMonster } from '@/services/monster';
 import { getDoc, doc } from 'firebase/firestore';
 import { FIREBASE_DB } from '@/firebaseConfig';
 import { updateUserProfile } from '@/services/user';
+import { getMonsterById } from '@/services/monster';
 
 type TurnInfo = {
   id: string;
@@ -103,29 +104,44 @@ const Combat = () => {
             setDefaultMonster(difficultyMultiplier);
           }
         } else {
-          const monsterIds = (questMonsters as string).split(',');
-          const selectedMonster = await getRandomMonster(monsterIds);
+          const monsterIds =
+            typeof questMonsters === 'string'
+              ? questMonsters.split(',').filter((id) => id.trim() !== '')
+              : [];
 
-          if (selectedMonster) {
-            setMonster({
-              name: selectedMonster.name,
-              maxHealth: Math.floor(
-                selectedMonster.attributes.health * 20 * difficultyMultiplier,
-              ),
-              health: Math.floor(
-                selectedMonster.attributes.health * 20 * difficultyMultiplier,
-              ),
-              power: Math.floor(
-                selectedMonster.attributes.power * difficultyMultiplier,
-              ),
-              speed: Math.floor(selectedMonster.attributes.speed),
-              spriteId: selectedMonster.spriteId as AnimatedSpriteID,
-            });
+          console.log('monsterIds', monsterIds);
+
+          if (monsterIds.length > 0) {
+            const randomIndex = Math.floor(Math.random() * monsterIds.length);
+            const selectedMonsterId = monsterIds[randomIndex];
+
+            const selectedMonster = await getMonsterById(selectedMonsterId);
+
+            console.log('selectedMonster', selectedMonster);
+
+            if (selectedMonster) {
+              setMonster({
+                name: selectedMonster.name,
+                maxHealth: Math.floor(
+                  selectedMonster.attributes.health * 20 * difficultyMultiplier,
+                ),
+                health: Math.floor(
+                  selectedMonster.attributes.health * 20 * difficultyMultiplier,
+                ),
+                power: Math.floor(
+                  selectedMonster.attributes.power * difficultyMultiplier,
+                ),
+                speed: Math.floor(selectedMonster.attributes.speed),
+                spriteId: selectedMonster.spriteId as AnimatedSpriteID,
+              });
+              setIsMonsterInitialized(true);
+            } else {
+              setDefaultMonster(difficultyMultiplier);
+            }
           } else {
             setDefaultMonster(difficultyMultiplier);
           }
         }
-        setIsMonsterInitialized(true);
       } catch (error) {
         console.error('Error initializing monster:', error);
         setDefaultMonster();

--- a/app/fight.tsx
+++ b/app/fight.tsx
@@ -82,9 +82,7 @@ const Combat = () => {
 
         if (isBoss === 'true') {
           const formattedQuestId = `quest_${questId}`;
-
           const questDocRef = doc(FIREBASE_DB, 'quests', formattedQuestId);
-
           const questDoc = await getDoc(questDocRef);
 
           if (questDoc.exists()) {
@@ -92,7 +90,7 @@ const Combat = () => {
             const bossData = questData.boss;
 
             setMonster({
-              name: questData.questName,
+              name: questData.questName.replace(/^hunt\s+/i, ''),
               maxHealth: Math.floor(
                 bossData.health * 20 * difficultyMultiplier,
               ),

--- a/components/QuestNodeModal.tsx
+++ b/components/QuestNodeModal.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { AnimatedSprite } from './AnimatedSprite';
+import { AnimatedSpriteID, SpriteState } from '@/constants/sprite';
+
+interface QuestNodeModalProps {
+  visible: boolean;
+  onClose: () => void;
+  nodeInfo: {
+    isBoss: boolean;
+    milestone: number;
+    possibleMonsters: AnimatedSpriteID[];
+  } | null;
+}
+
+export const QuestNodeModal = ({
+  visible,
+  onClose,
+  nodeInfo,
+}: QuestNodeModalProps) => {
+  if (!nodeInfo) return null;
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View style={styles.modalOverlay}>
+        <View style={styles.modalContent}>
+          <Text style={styles.title}>
+            {nodeInfo.isBoss ? 'Boss Node' : 'Quest Node'}
+          </Text>
+          <Text style={styles.milestone}>
+            Stage {Math.floor(nodeInfo.milestone / 50)}
+          </Text>
+
+          <Text style={styles.subtitle}>Possible encounters:</Text>
+          <View style={styles.monstersGrid}>
+            {nodeInfo.possibleMonsters.map((monsterId, index) => (
+              <View key={index} style={styles.monsterContainer}>
+                <AnimatedSprite
+                  id={monsterId as AnimatedSpriteID}
+                  width={120}
+                  height={120}
+                  state={SpriteState.IDLE}
+                />
+              </View>
+            ))}
+          </View>
+
+          <TouchableOpacity style={styles.button} onPress={onClose}>
+            <Text style={styles.buttonText}>OK</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContent: {
+    backgroundColor: 'white',
+    borderRadius: 12,
+    padding: 20,
+    width: '80%',
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  milestone: {
+    fontSize: 16,
+    marginBottom: 16,
+  },
+  subtitle: {
+    fontSize: 16,
+    marginBottom: 12,
+  },
+  monstersGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 10,
+    marginBottom: 20,
+  },
+  monsterContainer: {
+    width: 120,
+    height: 120,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  button: {
+    backgroundColor: '#007AFF',
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+  },
+  buttonText: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/components/QuestNodeModal.tsx
+++ b/components/QuestNodeModal.tsx
@@ -9,7 +9,10 @@ interface QuestNodeModalProps {
   nodeInfo: {
     isBoss: boolean;
     milestone: number;
-    possibleMonsters: AnimatedSpriteID[];
+    possibleMonsters: {
+      monsterId: string;
+      spriteId: AnimatedSpriteID;
+    }[];
   } | null;
 }
 
@@ -19,6 +22,8 @@ export const QuestNodeModal = ({
   nodeInfo,
 }: QuestNodeModalProps) => {
   if (!nodeInfo) return null;
+
+  console.log('possible monsters', nodeInfo.possibleMonsters);
 
   return (
     <Modal
@@ -38,10 +43,10 @@ export const QuestNodeModal = ({
 
           <Text style={styles.subtitle}>Possible encounters:</Text>
           <View style={styles.monstersGrid}>
-            {nodeInfo.possibleMonsters.map((monsterId, index) => (
-              <View key={index} style={styles.monsterContainer}>
+            {nodeInfo.possibleMonsters.map(({ monsterId, spriteId }) => (
+              <View key={monsterId} style={styles.monsterContainer}>
                 <AnimatedSprite
-                  id={monsterId as AnimatedSpriteID}
+                  id={spriteId}
                   width={120}
                   height={120}
                   state={SpriteState.IDLE}

--- a/services/workout.ts
+++ b/services/workout.ts
@@ -97,9 +97,9 @@ export const finishAndSaveWorkout = async (
       workoutHistory: [newWorkout, ...userData.workoutHistory],
       exp: userAfterExpGain.exp,
       attributePoints: userAfterExpGain.attributePoints,
-      // Add workout duration to activeWorkoutMinutes
-      // TODO: Change duration from seconds to minutes
-      activeWorkoutMinutes: currentWorkoutMinutes + newWorkout.duration,
+      // Convert seconds to minutes
+      activeWorkoutMinutes:
+        currentWorkoutMinutes + Math.floor(newWorkout.duration / 60),
     });
 
     console.log(


### PR DESCRIPTION
### Description
Brief description of your changes
Fixed a bug with boss names, fixed bug with workoutMinutes being logged as seconds. Tweaked progress bar

### List of changes
- Change 1
Tweaked the progress bar, nodes are now clickable and clicking on them will show Node number, and what monsters are possible to fight.

- Change 2
Progress through quest is replaced with a "ready to advance", which says 'ready...' if user has more than 30minutes, else it'll show what percent ready they are (for debugging purposes, its set to 1minute rn)

### Did you install additional dependencies?
- [ ] Yes

### Which part of the repository does your PR affect?
- [ ] Sign In
- [ ] Sign Up
- [ ] Onboarding
- [ ] Profile
- [ ] Workout
- [X] Quest
- [ ] Shop
- [ ] Social
- [ ] Assets
- [ ] Report
- [ ] Project Structure
- [ ] Other. If so, specify: