### PR TITLE
Fix: Speed system system in fight screen

### DIFF
--- a/app/fight.tsx
+++ b/app/fight.tsx
@@ -653,7 +653,7 @@ const Combat = () => {
                 height={48}
                 state={
                   currentTurnEntity === 'player'
-                    ? SpriteState.ATTACK_2
+                    ? SpriteState.IDLE
                     : SpriteState.MOVE
                 }
               />
@@ -683,7 +683,7 @@ const Combat = () => {
                 height={48}
                 state={
                   currentTurnEntity === 'monster'
-                    ? SpriteState.ATTACK_1
+                    ? SpriteState.IDLE
                     : SpriteState.MOVE
                 }
               />
@@ -981,8 +981,7 @@ const Combat = () => {
               {modalType === 'victory' ? (
                 <>
                   <Text className="text-2xl font-bold mb-4">
-                    You have defeated {isBossFight ? 'the Boss' : 'the monster'}
-                    !
+                    You have defeated {monster.name}!
                   </Text>
 
                   <View className="w-full relative items-center justify-center h-[160px] overflow-hidden mb-10">

--- a/app/fight.tsx
+++ b/app/fight.tsx
@@ -26,6 +26,7 @@ import { getMonsterById } from '@/services/monster';
 import clsx from 'clsx';
 import { getUserTotalAttributes } from '@/utils/user';
 import { useItemStore } from '@/store/item';
+import FQButton from '@/components/FQButton';
 
 const calculatePlayerLevel = (attributes: {
   power: number;
@@ -132,7 +133,6 @@ const Combat = () => {
                   speed: Math.floor(selectedMonster.attributes.speed),
                   spriteId: selectedMonster.spriteId as AnimatedSpriteID,
                 });
-                setIsMonsterInitialized(true);
               } else {
                 setDefaultMonster(difficultyMultiplier);
               }
@@ -145,6 +145,7 @@ const Combat = () => {
           setDefaultMonster();
         } finally {
           setIsInitializing(false);
+          setIsMonsterInitialized(true);
         }
       }
     };
@@ -626,8 +627,8 @@ const Combat = () => {
         <View className="h-24 rounded-xl p-4">
           <View className="h-full relative flex-row items-center">
             <View className="absolute left-4 right-4 top-2/3 h-[5px] bg-yellow border border-black">
-              <View className="absolute top-[-3px] left-0 w-[6px] h-[12px] bg-yellow rounded-full" />
-              <View className="absolute top-[-3px] right-0 w-[6px] h-[12px] bg-yellow rounded-full" />
+              <View className="absolute top-[-4px] -left-1 w-[6px] h-[12px] bg-yellow rounded-full border border-black" />
+              <View className="absolute top-[-4px] -right-1 w-[6px] h-[12px] bg-yellow rounded-full border border-black" />
             </View>
 
             <Animated.View
@@ -653,7 +654,8 @@ const Combat = () => {
                 width={48}
                 height={48}
                 state={
-                  currentTurnEntity === 'player'
+                  currentTurnEntity === 'player' ||
+                  currentTurnEntity === 'monster'
                     ? SpriteState.IDLE
                     : SpriteState.MOVE
                 }
@@ -683,7 +685,8 @@ const Combat = () => {
                 width={48}
                 height={48}
                 state={
-                  currentTurnEntity === 'monster'
+                  currentTurnEntity === 'monster' ||
+                  currentTurnEntity === 'player'
                     ? SpriteState.IDLE
                     : SpriteState.MOVE
                 }
@@ -793,7 +796,7 @@ const Combat = () => {
       >
         {renderTurnOrder()}
 
-        <View className="flex-1 justify-center items-center h-full">
+        <View className="flex-1 justify-end items-center h-full">
           <View className="w-full rounded-xl">
             <View className="flex-row justify-between items-start mb-[10px]">
               <View className="w-1/2 pr-4 bg-black/40 p-2 rounded">
@@ -813,14 +816,30 @@ const Combat = () => {
                 </Text>
               </View>
 
-              <View className="w-1/2 items-center">
-                <AnimatedSprite
-                  id={monster.spriteId}
-                  width={spriteSize}
-                  height={spriteSize}
-                  state={monsterSpriteState}
-                  direction="left"
-                />
+              <View
+                className="relative w-1/2 items-center"
+                style={{
+                  height: spriteSize,
+                }}
+              >
+                {isBoss === 'true' ? (
+                  <View className="absolute bottom-0">
+                    <AnimatedSprite
+                      id={monster.spriteId}
+                      width={spriteSize * 2}
+                      height={spriteSize * 2}
+                      state={monsterSpriteState}
+                      direction="left"
+                    />
+                  </View>
+                ) : (
+                  <AnimatedSprite
+                    id={monster.spriteId}
+                    width={spriteSize}
+                    height={spriteSize}
+                    state={monsterSpriteState}
+                  />
+                )}
               </View>
             </View>
 
@@ -1093,14 +1112,11 @@ const Combat = () => {
                 </>
               )}
 
-              <Pressable
-                className="w-full bg-blue py-4 rounded-xl shadow-lg active:bg-blue"
-                onPress={handleContinue}
-              >
+              <FQButton onPress={handleContinue} className="w-full">
                 <Text className="text-white text-xl font-bold tracking-wider text-center">
                   CONTINUE
                 </Text>
-              </Pressable>
+              </FQButton>
             </View>
           </View>
         </Modal>

--- a/app/fight.tsx
+++ b/app/fight.tsx
@@ -467,6 +467,7 @@ const Combat = () => {
   };
 
   const handlePotion = async (type: 'small' | 'large') => {
+    console.log(user, isAnimating, currentTurnEntity, potions[type]);
     if (
       !user?.id ||
       isAnimating ||
@@ -857,6 +858,7 @@ const Combat = () => {
             className={clsx('w-full p-2 bg-black/50 rounded max-h-[90px]', {
               hidden: combatLog.length === 0,
             })}
+            testID="combat-log"
           >
             {combatLog.slice(-3).map((log, index) => (
               <Text key={index} className="text-sm mb-1 text-white w-full">
@@ -883,6 +885,7 @@ const Combat = () => {
                 className={`bg-white/90 p-3 rounded shadow ${isAnimating || currentTurnEntity !== 'player' ? 'opacity-50' : ''}`}
                 onPress={() => handleAttack(false)}
                 disabled={isAnimating || currentTurnEntity !== 'player'}
+                testID="normal-attack-button"
               >
                 <Text className="text-center">Attack</Text>
               </Pressable>
@@ -900,6 +903,7 @@ const Combat = () => {
                   isAnimating ||
                   currentTurnEntity !== 'player'
                 }
+                testID="strong-attack-button"
               >
                 <Text className="text-center flex-row items-center justify-center">
                   Strong Attack
@@ -934,6 +938,7 @@ const Combat = () => {
                     ? 'opacity-50'
                     : ''
                 }`}
+                testID="small-potion-button"
                 onPress={() => handlePotion('small')}
                 disabled={
                   potions.small <= 0 ||
@@ -954,6 +959,7 @@ const Combat = () => {
                     ? 'opacity-50'
                     : ''
                 }`}
+                testID="large-potion-button"
                 onPress={() => handlePotion('large')}
                 disabled={
                   potions.large <= 0 ||

--- a/utils/user.ts
+++ b/utils/user.ts
@@ -1,3 +1,4 @@
+import { Item } from '@/types/item';
 import { User } from '@/types/user';
 
 export const getUserExpThreshold = (user: User) => {
@@ -8,4 +9,28 @@ export const getUserExpThreshold = (user: User) => {
     user.attributes.health * 200 +
     user.attributePoints * 200
   );
+};
+
+export const getUserTotalAttributes = (user: User, allItems: Item[]) => {
+  // Base stats from user profile
+  let computedPower = user.attributes.power;
+  let computedHealth = user.attributes.health;
+  let computedSpeed = user.attributes.speed;
+
+  // Fetch equipped items
+  const equipped = allItems.filter((item) =>
+    user.equippedItems.includes(item.id),
+  );
+
+  equipped.forEach((item) => {
+    computedPower += item.power;
+    computedHealth += item.health;
+    computedSpeed += item.speed;
+  });
+
+  return {
+    power: computedPower,
+    health: computedHealth,
+    speed: computedSpeed,
+  };
 };


### PR DESCRIPTION
### Description
Fix bugs in fight screen. Initially wanted to fix the UI for the speed bar, because the way the sprites moved did not provide much information to the user, but found other bugs whose fix ended up being to overhaul the way the turn system is implemented.

This PR changes the turn system to not be calculated statically at the start of the fight and instead dynamically changes as per an interval which updates each entity's position in the speed bar. Whoever gets to 100% first gets to do their turn. 

Moreover, fixed a bug where the player wasn't initialized with their true attributes. By that I mean the previous implementation didn't factor the user's equipped items, resulting in only the user's base attributes being calculated in the fight.

### List of changes
- Fix speed bar UI
- Refactor turn cycle computation
- Fix user total attributes not calculated as part of fight
- Add damaged animation

### Did you install additional dependencies?
- [ ] Yes

### Which part of the repository does your PR affect?
- [ ] Sign In
- [ ] Sign Up
- [ ] Onboarding
- [ ] Profile
- [ ] Workout
- [ ] Quest
- [ ] Shop
- [ ] Social
- [ ] Assets
- [ ] Report
- [ ] Project Structure
- [x] Other. If so, specify: Fight screen