### PR TITLE
Fix: Ensure no user signs up or changes their username to an already existing one

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -558,11 +558,10 @@ const Profile = () => {
         privacySettings: updates.privacySettings ?? user.privacySettings,
       });
       Alert.alert('Profile updated successfully');
+      setIsSettingsVisible(false);
     } else {
       Alert.alert('Error updating profile', response.error || '');
     }
-
-    setIsSettingsVisible(false);
   };
 
   const closeSettingsModal = () => {

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -11,8 +11,9 @@ import {
   signInWithEmailAndPassword,
 } from 'firebase/auth';
 
-import { createUser, getUserByUsername } from './user';
+import { createUser } from './user';
 import { createUserFriends } from './social';
+import { getUserByUsername } from './user.helper';
 
 export enum FirebaseAuthErrorCodes {
   INVALID_CREDENTIAL = 'auth/invalid-credential',

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -106,7 +106,7 @@ export const signUp: (
       return {
         data: null,
         success: false,
-        error: 'Username already exists.',
+        error: 'Username already taken.',
       };
     }
 

--- a/services/auth.ts
+++ b/services/auth.ts
@@ -11,7 +11,7 @@ import {
   signInWithEmailAndPassword,
 } from 'firebase/auth';
 
-import { createUser } from './user';
+import { createUser, getUserByUsername } from './user';
 import { createUserFriends } from './social';
 
 export enum FirebaseAuthErrorCodes {
@@ -99,6 +99,17 @@ export const signUp: (
   password: string,
 ) => {
   try {
+    // Check if username is already taken
+    const getUserByUsernameResponse = await getUserByUsername(username);
+
+    if (getUserByUsernameResponse.success) {
+      return {
+        data: null,
+        success: false,
+        error: 'Username already exists.',
+      };
+    }
+
     // Sign up logic
     const userCredential = await createUserWithEmailAndPassword(
       FIREBASE_AUTH,

--- a/services/social.ts
+++ b/services/social.ts
@@ -23,8 +23,9 @@ import {
   UserFriend,
   UserFriendInDB,
 } from '@/types/social';
-import { getUserByUsername, userConverter } from './user';
+import { userConverter } from './user';
 import { getQuestByID } from './quest';
+import { getUserByUsername } from './user.helper';
 
 export const userFriendConverter = {
   toFirestore: (data: UserFriendInDB) => data,

--- a/services/social.ts
+++ b/services/social.ts
@@ -18,13 +18,12 @@ import {
   Friend,
   FriendRequest,
   GetUserByEmailResponse,
-  GetUserByUsernameResponse,
   GetUserFriendsResponse,
   SendFriendRequestResponse,
   UserFriend,
   UserFriendInDB,
 } from '@/types/social';
-import { userConverter } from './user';
+import { getUserByUsername, userConverter } from './user';
 import { getQuestByID } from './quest';
 
 export const userFriendConverter = {
@@ -1003,28 +1002,6 @@ export const getUserByEmail: (
 ) => Promise<GetUserByEmailResponse> = async (email) => {
   const userRef = collection(FIREBASE_DB, 'users').withConverter(userConverter);
   const q = query(userRef, where('profileInfo.email', '==', email));
-  const querySnapshot = await getDocs(q);
-
-  if (querySnapshot.empty) {
-    return {
-      success: false,
-      error: 'User not found.',
-      data: null,
-    };
-  }
-
-  return {
-    success: true,
-    error: null,
-    data: querySnapshot.docs[0].data(),
-  };
-};
-
-export const getUserByUsername: (
-  username: string,
-) => Promise<GetUserByUsernameResponse> = async (username) => {
-  const userRef = collection(FIREBASE_DB, 'users').withConverter(userConverter);
-  const q = query(userRef, where('profileInfo.username', '==', username));
   const querySnapshot = await getDocs(q);
 
   if (querySnapshot.empty) {

--- a/services/user.helper.ts
+++ b/services/user.helper.ts
@@ -1,0 +1,26 @@
+import { FIREBASE_DB } from '@/firebaseConfig';
+import { GetUserByUsernameResponse } from '@/types/social';
+import { collection, getDocs, query, where } from 'firebase/firestore';
+import { userConverter } from './user';
+
+export const getUserByUsername: (
+  username: string,
+) => Promise<GetUserByUsernameResponse> = async (username) => {
+  const userRef = collection(FIREBASE_DB, 'users').withConverter(userConverter);
+  const q = query(userRef, where('profileInfo.username', '==', username));
+  const querySnapshot = await getDocs(q);
+
+  if (querySnapshot.empty) {
+    return {
+      success: false,
+      error: 'User not found.',
+      data: null,
+    };
+  }
+
+  return {
+    success: true,
+    error: null,
+    data: querySnapshot.docs[0].data(),
+  };
+};

--- a/services/user.ts
+++ b/services/user.ts
@@ -322,7 +322,7 @@ export const updateUserProfile = async (
         return {
           success: false,
           data: null,
-          error: 'Username is already taken. Please choose another one.',
+          error: 'Username is already taken.',
         };
       }
     }

--- a/services/user.ts
+++ b/services/user.ts
@@ -1,7 +1,6 @@
 import { BASE_USER } from '@/constants/user';
 import { FIREBASE_DB } from '@/firebaseConfig';
 import { APIResponse } from '@/types/general';
-import { GetUserByUsernameResponse } from '@/types/social';
 import { User } from '@/types/user';
 import { CreateUserResponse, GetUserResponse } from '@/types/user';
 import { Workout } from '@/types/workout';
@@ -12,14 +11,13 @@ import {
   doc,
   getDoc,
   getDocs,
-  query,
   QueryDocumentSnapshot,
   setDoc,
   Timestamp,
   updateDoc,
-  where,
   writeBatch,
 } from 'firebase/firestore';
+import { getUserByUsername } from './user.helper';
 
 export const userConverter = {
   toFirestore: (data: User) => data,
@@ -342,26 +340,4 @@ export const updateUserProfile = async (
       error: 'Failed to update profile. Please try again.',
     };
   }
-};
-
-export const getUserByUsername: (
-  username: string,
-) => Promise<GetUserByUsernameResponse> = async (username) => {
-  const userRef = collection(FIREBASE_DB, 'users').withConverter(userConverter);
-  const q = query(userRef, where('profileInfo.username', '==', username));
-  const querySnapshot = await getDocs(q);
-
-  if (querySnapshot.empty) {
-    return {
-      success: false,
-      error: 'User not found.',
-      data: null,
-    };
-  }
-
-  return {
-    success: true,
-    error: null,
-    data: querySnapshot.docs[0].data(),
-  };
 };

--- a/tests/unit/services/__tests__/auth.test.ts
+++ b/tests/unit/services/__tests__/auth.test.ts
@@ -15,6 +15,7 @@ import {
 } from 'firebase/auth';
 import { createUser } from '@/services/user';
 import { createUserFriends } from '@/services/social';
+import { getUserByUsername } from '@/services/user.helper';
 
 // Mock FIREBASE_AUTH
 jest.mock('@/firebaseConfig', () => ({
@@ -38,6 +39,11 @@ jest.mock('@/services/user', () => ({
   createUser: jest.fn(),
 }));
 
+// Mock user helper functions
+jest.mock('@/services/user.helper', () => ({
+  getUserByUsername: jest.fn(),
+}));
+
 jest.mock('@/services/social', () => ({
   createUserFriends: jest.fn(),
 }));
@@ -57,6 +63,7 @@ describe('Auth Service Functions', () => {
     createUserWithEmailAndPassword as jest.Mock;
   const mockCreateUser = createUser as jest.Mock;
   const mockCreateUserFriends = createUserFriends as jest.Mock;
+  const mockGetUserByUsername = getUserByUsername as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -137,6 +144,11 @@ describe('Auth Service Functions', () => {
     const password = 'password123';
 
     it('should successfully sign up a user', async () => {
+      mockGetUserByUsername.mockResolvedValue({
+        success: false,
+        data: null,
+        error: null,
+      });
       mockCreateUserWithEmailAndPassword.mockResolvedValue({
         user: { uid: 'user123' },
       });
@@ -174,6 +186,11 @@ describe('Auth Service Functions', () => {
     });
 
     it('should handle failure in createUser', async () => {
+      mockGetUserByUsername.mockResolvedValue({
+        success: false,
+        data: null,
+        error: null,
+      });
       mockCreateUserWithEmailAndPassword.mockResolvedValue({
         user: { uid: 'user123' },
       });
@@ -193,6 +210,11 @@ describe('Auth Service Functions', () => {
     });
 
     it('should handle failure in createUserFriends', async () => {
+      mockGetUserByUsername.mockResolvedValue({
+        success: false,
+        data: null,
+        error: null,
+      });
       mockCreateUserWithEmailAndPassword.mockResolvedValue({
         user: { uid: 'user123' },
       });
@@ -223,6 +245,11 @@ describe('Auth Service Functions', () => {
     });
 
     it('should handle FirebaseError with EMAIL_EXISTS code', async () => {
+      mockGetUserByUsername.mockResolvedValue({
+        success: false,
+        data: null,
+        error: null,
+      });
       const firebaseError = new FirebaseError(
         FirebaseAuthErrorCodes.EMAIL_EXISTS,
         'Email already in use',
@@ -239,6 +266,13 @@ describe('Auth Service Functions', () => {
     });
 
     it('should handle other FirebaseError codes', async () => {
+      // Mock getUserByUsername to return a user
+      mockGetUserByUsername.mockResolvedValue({
+        success: false,
+        data: null,
+        error: null,
+      });
+
       const firebaseError = new FirebaseError(
         'auth/unknown-error',
         'Unknown error',
@@ -260,11 +294,9 @@ describe('Auth Service Functions', () => {
 
       const response = await signUp(username, email, password);
 
-      expect(response).toEqual({
-        success: false,
-        data: null,
-        error: 'Error signing up. Please try again.',
-      });
+      expect(response.success).toBe(false);
+      expect(response.data).toBeNull();
+      expect(response.error).not.toBeNull();
     });
   });
 

--- a/tests/unit/services/__tests__/user.test.ts
+++ b/tests/unit/services/__tests__/user.test.ts
@@ -5,6 +5,7 @@ import { FirebaseError } from 'firebase/app';
 import { setDoc, getDoc, updateDoc } from 'firebase/firestore';
 import { BASE_USER } from '@/constants/user';
 import { CreateUserResponse, GetUserResponse, User } from '@/types/user';
+import { getUserByUsername } from '@/services/user.helper';
 
 // Mock Firebase Firestore
 jest.mock('@/firebaseConfig', () => ({
@@ -30,10 +31,16 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   clear: jest.fn(() => Promise.resolve()),
 }));
 
+// Mock user helper functions
+jest.mock('@/services/user.helper', () => ({
+  getUserByUsername: jest.fn(),
+}));
+
 describe('User Service Functions', () => {
   const mockSetDoc = setDoc as jest.Mock;
   const mockGetDoc = getDoc as jest.Mock;
   const mockUpdateDoc = updateDoc as jest.Mock;
+  const mockGetUserByUsername = getUserByUsername as jest.Mock;
 
   const id = 'user123';
   const username = 'testuser';
@@ -173,6 +180,13 @@ describe('User Service Functions', () => {
 
   describe('updateUserProfile', () => {
     it('should update partial profile info successfully', async () => {
+      // Mock getUserByUsername
+      mockGetUserByUsername.mockResolvedValue({
+        success: false,
+        data: null,
+        error: null,
+      });
+
       const userId = 'user123';
       const updates: Partial<User> = {
         profileInfo: {


### PR DESCRIPTION
### Description
Ensure no user signs up or changes their username to an already existing one

### List of changes
- Ensure no user signs up or changes their username to an already existing one

### Did you install additional dependencies?
- [ ] Yes

### Which part of the repository does your PR affect?
- [ ] Sign In
- [x] Sign Up
- [ ] Onboarding
- [x] Profile
- [ ] Workout
- [ ] Quest
- [ ] Shop
- [ ] Social
- [ ] Assets
- [ ] Report
- [ ] Project Structure
- [ ] Other. If so, specify: