### PR TITLE
Fix: Update variables for exp and quest progress to production

### DIFF
--- a/app/(tabs)/quest.tsx
+++ b/app/(tabs)/quest.tsx
@@ -286,7 +286,7 @@ const Quest = () => {
 
   const handleAdvance = async () => {
     if (activeQuest && user?.id) {
-      if (user.activeWorkoutMinutes < 1) {
+      if (user.activeWorkoutMinutes < 30) {
         Alert.alert(
           'Not Strong Enough...',
           "You'll need to train more before challenging this foe. Return after training!",
@@ -314,13 +314,13 @@ const Quest = () => {
         const uniqueKey = Date.now();
 
         const result = await updateUserProfile(user.id, {
-          activeWorkoutMinutes: user.activeWorkoutMinutes - 1,
+          activeWorkoutMinutes: user.activeWorkoutMinutes - 30,
         });
 
         if (result.success) {
           setUser({
             ...user,
-            activeWorkoutMinutes: user.activeWorkoutMinutes - 1,
+            activeWorkoutMinutes: user.activeWorkoutMinutes - 30,
           });
 
           setLoading(false);

--- a/app/(workout)/edit-workout-template.tsx
+++ b/app/(workout)/edit-workout-template.tsx
@@ -12,6 +12,7 @@ import {
   Dimensions,
   LayoutAnimation,
   ScrollView,
+  Alert,
 } from 'react-native';
 import 'react-native-get-random-values';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -335,6 +336,11 @@ const NewWorkout = () => {
       console.log('Successfully saved workout template');
     } else {
       console.error('Failed to save workout template');
+      Alert.alert(
+        'Error saving workout template',
+        saveWorkoutTemplateResponse.error ||
+          'An error occurred while saving the workout template.',
+      );
 
       // Revert user store
       setUser(oldUser);

--- a/app/(workout)/new-workout.tsx
+++ b/app/(workout)/new-workout.tsx
@@ -440,7 +440,7 @@ const NewWorkout = () => {
       return;
     }
 
-    const expGain = seconds * 500;
+    const expGain = seconds;
 
     setModalContent({
       title: 'Finished?',
@@ -558,10 +558,7 @@ const NewWorkout = () => {
     // Print workout object
     printWorkout(newWorkout);
 
-    const userAfterExpGain = updateUserAfterExpGain(
-      user,
-      newWorkout.duration * 500,
-    );
+    const userAfterExpGain = updateUserAfterExpGain(user, newWorkout.duration);
 
     // Optimistic update to user's workout history and exp
     const oldUser = user;

--- a/services/workout.ts
+++ b/services/workout.ts
@@ -2,7 +2,7 @@ import { doc, getDoc, updateDoc, collection } from 'firebase/firestore';
 import { FIREBASE_DB } from '@/firebaseConfig';
 import { APIResponse } from '@/types/general';
 import { userConverter } from './user';
-import { addToUserWorkouts, updateUserAfterExpGain } from '@/utils/workout';
+import { updateUserAfterExpGain } from '@/utils/workout';
 import { ExerciseDisplay, Workout } from '@/types/workout';
 import { User } from '@/types/user';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -36,7 +36,7 @@ export const updateEXP: (
       throw new Error('User data not found.');
     }
 
-    const expGain = duration * 500;
+    const expGain = duration;
 
     // Get new user exp amount
     const userAfterExpGain = updateUserAfterExpGain(userData, expGain);
@@ -87,7 +87,7 @@ export const finishAndSaveWorkout = async (
     }
 
     const newWorkout = workout;
-    const expGain = newWorkout.duration * 500;
+    const expGain = newWorkout.duration;
     const currentWorkoutMinutes = userData.activeWorkoutMinutes || 0;
 
     // Get new user exp amount
@@ -146,16 +146,39 @@ export const saveWorkoutTemplate: (
     const userData = userSnap.data();
 
     if (!userData) {
-      throw new Error('User data not found.');
+      return {
+        data: null,
+        success: false,
+        error: 'User data not found.',
+      };
     }
 
     const newWorkout = workout;
 
-    // Get new user exp amount
-    const userAfterWorkoutAdd = addToUserWorkouts(userData, newWorkout);
+    console.log('new workout', newWorkout);
+
+    // Check if workout template with the same title already exists
+    const isWorkoutTemplateExists = userData.savedWorkoutTemplates.some(
+      (workout) => workout.title === newWorkout.title,
+    );
+
+    if (isWorkoutTemplateExists) {
+      return {
+        data: null,
+        success: false,
+        error: 'Workout template with the same title already exists.',
+      };
+    }
+
+    console.log('user data', userData);
+
+    const newSavedWorkoutTemplates = [
+      newWorkout,
+      ...userData.savedWorkoutTemplates,
+    ];
 
     await updateDoc(userRef, {
-      savedWorkoutTemplates: userAfterWorkoutAdd.savedWorkoutTemplates,
+      savedWorkoutTemplates: newSavedWorkoutTemplates,
     });
 
     console.log('successfully added ' + newWorkout.title + 'to user workouts.');

--- a/tests/unit/services/__tests__/workout.test.ts
+++ b/tests/unit/services/__tests__/workout.test.ts
@@ -269,8 +269,8 @@ describe('Workout Service Functions', () => {
 
       // Check if user's exp has been updated correctly
       expect(mockUpdateDoc).toHaveBeenCalledWith(expect.objectContaining({}), {
-        exp: 3600,
-        attributePoints: 0,
+        exp: 500,
+        attributePoints: 2,
       });
     });
 

--- a/tests/unit/services/__tests__/workout.test.ts
+++ b/tests/unit/services/__tests__/workout.test.ts
@@ -143,7 +143,7 @@ describe('Workout Service Functions', () => {
   const userData = {
     ...BASE_USER,
     id: 'user1234',
-    savedWorkouts: [],
+    savedWorkoutTemplates: [],
   };
 
   // basic chest workout
@@ -161,7 +161,7 @@ describe('Workout Service Functions', () => {
   const userDataWithWorkout = {
     ...BASE_USER,
     id: 'userwithworkout',
-    savedWorkouts: [exampleWorkout],
+    savedWorkoutTemplates: [exampleWorkout],
   };
 
   beforeEach(() => {
@@ -169,7 +169,7 @@ describe('Workout Service Functions', () => {
   });
 
   // Tests for saving and editing workouts
-  describe('saving and editing workout templates', () => {
+  describe('saving, editingm, and deleting workout templates', () => {
     const userId = 'user1234';
 
     it('should add to saved workouts successfully', async () => {
@@ -269,8 +269,8 @@ describe('Workout Service Functions', () => {
 
       // Check if user's exp has been updated correctly
       expect(mockUpdateDoc).toHaveBeenCalledWith(expect.objectContaining({}), {
-        exp: 2000,
-        attributePoints: 116,
+        exp: 3600,
+        attributePoints: 0,
       });
     });
 

--- a/tests/unit/utils/__tests__/user.test.ts
+++ b/tests/unit/utils/__tests__/user.test.ts
@@ -17,7 +17,7 @@ describe('User Utility Functions', () => {
 
       const expThreshold = getUserExpThreshold(user);
 
-      expect(expThreshold).toBe(4000);
+      expect(expThreshold).toBe(1500);
     });
 
     it('should return the correct exp threshold #2', () => {
@@ -33,7 +33,7 @@ describe('User Utility Functions', () => {
 
       const expThreshold = getUserExpThreshold(user);
 
-      expect(expThreshold).toBe(4200);
+      expect(expThreshold).toBe(1600);
     });
 
     it('should return the correct exp threshold #3', () => {
@@ -49,7 +49,7 @@ describe('User Utility Functions', () => {
 
       const expThreshold = getUserExpThreshold(user);
 
-      expect(expThreshold).toBe(4800);
+      expect(expThreshold).toBe(1900);
     });
 
     it('should return the correct exp threshold #4', () => {
@@ -65,7 +65,7 @@ describe('User Utility Functions', () => {
 
       const expThreshold = getUserExpThreshold(user);
 
-      expect(expThreshold).toBe(5000);
+      expect(expThreshold).toBe(2000);
     });
 
     it('should return the correct exp threshold #5', () => {
@@ -81,7 +81,7 @@ describe('User Utility Functions', () => {
 
       const expThreshold = getUserExpThreshold(user);
 
-      expect(expThreshold).toBe(8000);
+      expect(expThreshold).toBe(3500);
     });
 
     it('should return the correct exp threshold #6', () => {
@@ -97,7 +97,7 @@ describe('User Utility Functions', () => {
 
       const expThreshold = getUserExpThreshold(user);
 
-      expect(expThreshold).toBe(13000);
+      expect(expThreshold).toBe(6000);
     });
 
     it('should return the correct exp threshold #7', () => {
@@ -113,7 +113,7 @@ describe('User Utility Functions', () => {
 
       const expThreshold = getUserExpThreshold(user);
 
-      expect(expThreshold).toBe(25000);
+      expect(expThreshold).toBe(12000);
     });
   });
 });

--- a/tests/unit/utils/__tests__/workout.test.ts
+++ b/tests/unit/utils/__tests__/workout.test.ts
@@ -23,7 +23,7 @@ describe('Workout Utility Functions', () => {
 
       const updatedUser1 = updateUserAfterExpGain(user1, 1000);
 
-      expect(updatedUser1.exp).toBe(2000);
+      expect(updatedUser1.exp).toBe(500);
     });
 
     it('should update user exp #3', () => {
@@ -34,7 +34,7 @@ describe('Workout Utility Functions', () => {
 
       const updatedUser1 = updateUserAfterExpGain(user1, 1000);
 
-      expect(updatedUser1.exp).toBe(3000);
+      expect(updatedUser1.exp).toBe(1500);
     });
 
     it('should level up a user and give them attribute points #1', () => {
@@ -45,20 +45,8 @@ describe('Workout Utility Functions', () => {
 
       const updatedUser1 = updateUserAfterExpGain(user1, 1000);
 
-      expect(updatedUser1.exp).toBe(0);
-      expect(updatedUser1.attributePoints).toBe(1);
-    });
-
-    it('should level up a user and give them attribute points #1', () => {
-      const user1: User = {
-        ...BASE_USER,
-        exp: 3000,
-      };
-
-      const updatedUser1 = updateUserAfterExpGain(user1, 2000);
-
-      expect(updatedUser1.exp).toBe(1000);
-      expect(updatedUser1.attributePoints).toBe(1);
+      expect(updatedUser1.exp).toBe(900);
+      expect(updatedUser1.attributePoints).toBe(2);
     });
 
     it('should level up a user and give them attribute points #2', () => {
@@ -67,10 +55,22 @@ describe('Workout Utility Functions', () => {
         exp: 3000,
       };
 
+      const updatedUser1 = updateUserAfterExpGain(user1, 2000);
+
+      expect(updatedUser1.exp).toBe(200);
+      expect(updatedUser1.attributePoints).toBe(3);
+    });
+
+    it('should level up a user and give them attribute points #3', () => {
+      const user1: User = {
+        ...BASE_USER,
+        exp: 3000,
+      };
+
       const updatedUser1 = updateUserAfterExpGain(user1, 3000);
 
-      expect(updatedUser1.exp).toBe(2000);
-      expect(updatedUser1.attributePoints).toBe(1);
+      expect(updatedUser1.exp).toBe(1200);
+      expect(updatedUser1.attributePoints).toBe(3);
     });
 
     it('should level up a user and give them attribute points multiple times #1', () => {
@@ -81,7 +81,7 @@ describe('Workout Utility Functions', () => {
 
       const updatedUser1 = updateUserAfterExpGain(user1, 9000);
 
-      expect(updatedUser1.attributePoints).toBe(2);
+      expect(updatedUser1.attributePoints).toBe(5);
     });
 
     it('should level up a user and give them attribute points multiple times #2', () => {
@@ -92,7 +92,7 @@ describe('Workout Utility Functions', () => {
 
       const updatedUser1 = updateUserAfterExpGain(user1, 15000);
 
-      expect(updatedUser1.attributePoints).toBe(3);
+      expect(updatedUser1.attributePoints).toBe(8);
     });
   });
 });

--- a/utils/user.ts
+++ b/utils/user.ts
@@ -3,11 +3,10 @@ import { User } from '@/types/user';
 
 export const getUserExpThreshold = (user: User) => {
   return (
-    1000 + // Base exp
-    user.attributes.power * 200 +
-    user.attributes.speed * 200 +
-    user.attributes.health * 200 +
-    user.attributePoints * 200
+    user.attributes.power * 100 +
+    user.attributes.speed * 100 +
+    user.attributes.health * 100 +
+    user.attributePoints * 100
   );
 };
 


### PR DESCRIPTION
### Description
Update variables for exp and quest progress to production

### List of changes
- Set workout exp gain to 1 second = 1 exp point
- Set user activeWorkoutMinutes reduction from 1 to 30
- Update userExpThreshold to be far lower. Base character will level up after 25 minutes

### Did you install additional dependencies?
- [ ] Yes

### Which part of the repository does your PR affect?
- [ ] Sign In
- [ ] Sign Up
- [ ] Onboarding
- [ ] Profile
- [x] Workout
- [x] Quest
- [ ] Fight
- [ ] Shop
- [ ] Social
- [ ] Assets
- [ ] Report
- [ ] Project Structure
- [ ] Other. If so, specify: