### PR TITLE
Hotfix: Fix converting from seconds to minutes after doing workout

### DIFF
--- a/app/(workout)/new-workout.tsx
+++ b/app/(workout)/new-workout.tsx
@@ -568,7 +568,7 @@ const NewWorkout = () => {
       exp: userAfterExpGain.exp,
       attributePoints: userAfterExpGain.attributePoints,
       activeWorkoutMinutes:
-        userAfterExpGain.activeWorkoutMinutes + newWorkout.duration,
+        userAfterExpGain.activeWorkoutMinutes + newWorkout.duration / 60,
     });
 
     console.log('User workout history and exp updated.');

--- a/services/workout.ts
+++ b/services/workout.ts
@@ -98,8 +98,7 @@ export const finishAndSaveWorkout = async (
       exp: userAfterExpGain.exp,
       attributePoints: userAfterExpGain.attributePoints,
       // Convert seconds to minutes
-      activeWorkoutMinutes:
-        currentWorkoutMinutes + Math.floor(newWorkout.duration / 60),
+      activeWorkoutMinutes: currentWorkoutMinutes + newWorkout.duration / 60,
     });
 
     console.log(


### PR DESCRIPTION
### Description
Hotfix: Fix converting from seconds to minutes after doing workout

### List of changes
- activeWorkoutMinutes was rounded down so doing a workout less than one minute does not register
- Fix not converting from seconds to minutes for activeWorkoutMinutes in FE after finishing a workout.

### Did you install additional dependencies?
- [ ] Yes

### Which part of the repository does your PR affect?
- [ ] Sign In
- [ ] Sign Up
- [ ] Onboarding
- [ ] Profile
- [x] Workout
- [ ] Quest
- [ ] Fight
- [ ] Shop
- [ ] Social
- [ ] Assets
- [ ] Report
- [ ] Project Structure
- [ ] Other. If so, specify: